### PR TITLE
subset to genes used in original RxRx benchmark

### DIFF
--- a/mcli/mosaicfm-70m-rxrx-known-rels.yaml
+++ b/mcli/mosaicfm-70m-rxrx-known-rels.yaml
@@ -172,10 +172,13 @@ parameters:
       cfg:
         known_rels:
           remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/rxrx-known-rels/known-rels.pkl"
-          local: "/vevo/data/download/rxrx-known-rels/known-rels.pkl"
+          local: "/tahoe/data/download/rxrx-known-rels/known-rels.pkl"
         gene_metadata:
           remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/rxrx-known-rels/gene-metadata.csv"
-          local: "/vevo/data/download/rxrx-known-rels/gene-metadata.csv"
+          local: "/tahoe/data/download/rxrx-known-rels/gene-metadata.csv"
+        rxrx_perturbations:
+          remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/rxrx-known-rels/example-embs-metadata.csv"
+          local: "/tahoe/data/download/rxrx-known-rels/rxrx-perturbations.csv"
   loggers:
     wandb:
       project: vevo-scgpt

--- a/mosaicfm/tasks/rxrx_known_rels.py
+++ b/mosaicfm/tasks/rxrx_known_rels.py
@@ -146,6 +146,7 @@ class RxRxKnownRels(Callback):
         super().__init__()
         self.known_rels_cfg = cfg["known_rels"]
         self.gene_metadata_cfg = cfg["gene_metadata"]
+        self.rxrx_perturbations_cfg = cfg["rxrx_perturbations"]
 
     def fit_end(self, state: State, logger: Logger):
 
@@ -161,6 +162,10 @@ class RxRxKnownRels(Callback):
         download_file_from_s3_url(
             s3_url=self.gene_metadata_cfg["remote"],
             local_file_path=self.gene_metadata_cfg["local"],
+        )
+        download_file_from_s3_url(
+            s3_url=self.rxrx_perturbations_cfg["remote"],
+            local_file_path=self.rxrx_perturbations_cfg["local"],
         )
 
         # open known relationships
@@ -180,11 +185,17 @@ class RxRxKnownRels(Callback):
             )
             gene_embs = gene_embs[gene_metadata["token_id"].to_numpy()]
 
-        features = pd.DataFrame(gene_embs)
+        # subset to genes used in the original RxRx benchmark
+        rxrx_perturbations = pd.read_csv(self.rxrx_perturbations_cfg["local"])
+        rows_to_keep = gene_metadata["gene_symbol"].isin(
+            rxrx_perturbations["perturbation"].unique()
+        )
+        metadata = gene_metadata[rows_to_keep]
+        features = pd.DataFrame(gene_embs[rows_to_keep])
 
         # run benchmark
         results = known_relationship_benchmark(
-            Bunch(metadata=gene_metadata, features=features),
+            Bunch(metadata=metadata, features=features),
             pert_col="gene_symbol",
             known_rels=known_rels,
             log_stats=True,

--- a/mosaicfm/tasks/rxrx_known_rels.py
+++ b/mosaicfm/tasks/rxrx_known_rels.py
@@ -188,7 +188,7 @@ class RxRxKnownRels(Callback):
         # subset to genes used in the original RxRx benchmark
         rxrx_perturbations = pd.read_csv(self.rxrx_perturbations_cfg["local"])
         rows_to_keep = gene_metadata["gene_symbol"].isin(
-            rxrx_perturbations["perturbation"].unique()
+            rxrx_perturbations["perturbation"].unique(),
         )
         metadata = gene_metadata[rows_to_keep]
         features = pd.DataFrame(gene_embs[rows_to_keep])

--- a/runai/mosaicfm-70m-rxrx-known-rels.yaml
+++ b/runai/mosaicfm-70m-rxrx-known-rels.yaml
@@ -4,6 +4,7 @@ device_train_batch_size: 400
 global_train_batch_size: 400
 device_eval_batch_size: 400
 device_train_microbatch_size: "auto"
+load_path: "/tahoe/mosaicfm/models/mosaicfm-70m-merged/best-model.pt"
 vocabulary:
   remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/vevo_v2_vocab.json"
   local: "vocab.json"
@@ -64,10 +65,10 @@ train_loader:
     streams:
       tahoe:
         remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v1/train/"
-        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/tahoe_merged_MDS/train"
+        local: "/tahoe/mosaicfm/datasets/vevo_merged_jan_2025/tahoe_merged_MDS/train"
       cellxgene:
         remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cellxgene_2025_01_21_merged_MDS/train/"
-        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/cellxgene_merged_MDS/train"
+        local: "/tahoe/mosaicfm/datasets/vevo_merged_jan_2025/cellxgene_merged_MDS/train"
     download_timeout: 300
     allow_unsafe_types: True
     shuffle: True
@@ -83,10 +84,10 @@ valid_loader:
     streams:
       tahoe:
         remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v1/valid/"
-        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/tahoe_merged_MDS/valid"
+        local: "/tahoe/mosaicfm/datasets/vevo_merged_jan_2025/tahoe_merged_MDS/valid"
       cellxgene:
         remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cellxgene_2025_01_21_merged_MDS/valid/"
-        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/cellxgene_merged_MDS/valid"
+        local: "/tahoe/mosaicfm/datasets/vevo_merged_jan_2025/cellxgene_merged_MDS/valid"
     download_timeout: 300
     allow_unsafe_types: True
     shuffle: False
@@ -118,7 +119,8 @@ algorithms:
 precision: amp_bf16
 eval_interval: "1000ba"
 eval_subset_num_batches: 100
-max_duration: "10ba"
+# max_duration: "10ba"
+max_duration: "194290ba"
 fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: DEFAULT
@@ -137,10 +139,13 @@ callbacks:
     cfg:
       known_rels:
         remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/rxrx-known-rels/known-rels.pkl"
-        local: "/vevo/data/download/rxrx-known-rels/known-rels.pkl"
+        local: "/tahoe/data/download/rxrx-known-rels/known-rels.pkl"
       gene_metadata:
         remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/rxrx-known-rels/gene-metadata.csv"
-        local: "/vevo/data/download/rxrx-known-rels/gene-metadata.csv"
+        local: "/tahoe/data/download/rxrx-known-rels/gene-metadata.csv"
+      rxrx_perturbations:
+        remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/rxrx-known-rels/example-embs-metadata.csv"
+        local: "/tahoe/data/download/rxrx-known-rels/rxrx-perturbations.csv"
 loggers:
   wandb:
     project: vevo-scgpt


### PR DESCRIPTION
We're still seeing low performance for MosaicFM compared to other embeddings, but this should fix the uniformly-0.1 performance we were seeing before (though that is expected for an untrained model).