### PR TITLE
Cellclass fix

### DIFF
--- a/mcli/mosaicfm-70m-cell-classification.yaml
+++ b/mcli/mosaicfm-70m-cell-classification.yaml
@@ -1,0 +1,246 @@
+integrations:
+- integration_type: git_repo
+  git_repo: tahoebio/mosaicfm
+  git_branch: cellclass-fix
+  # git_commit:  # OR use your commit hash
+  pip_install: -e . --no-deps
+  ssh_clone: true  # Should be true if using a private repo
+
+# We are fetching, converting, and training on the 'val' split
+# as it is small and quick to get going for this demo.
+# For real training runs, follow the instructions in `llm-foundry/scripts/train/provisioning-request.yaml`
+# to convert and host the full 'train' dataset.
+command: |
+  cd mosaicfm/scripts
+  composer train.py /mnt/config/parameters.yaml
+image: vevotx/mosaicfm:1.1.0
+env_variables:
+  MOSAICML_PLATFORM: False #Logging metadata to MosaicML platform is disabled, since it seems to timeout
+  OPENBLAS_NUM_THREADS: 1 # Prevents an issue with k-nearest neighbors in the cell-class callback
+name: mosaicfm-70m
+
+compute:
+  gpus: 16 # Number of GPUs to use
+  cluster: r18z1p1
+scheduling:
+  max_duration: 0.5 # Maximum duration of the run in hours
+
+  ## These configurations are optional
+  # cluster:
+  # gpu_type: a100_80gb # Type of GPU to use. We use a100_80gb in our experiments
+
+
+# The below is injected as a YAML file: /mnt/config/parameters.yaml
+# but is not used in this example.
+parameters:
+  global_seed: 777
+  seed: ${global_seed}
+  device_train_batch_size: 400
+  global_train_batch_size: 4800
+  device_eval_batch_size: 400
+  device_train_microbatch_size: "auto"
+  vocabulary:
+    remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/vevo_v2_vocab.json"
+    local: "vocab.json"
+  model:
+    name: mosaicfm
+    d_model: 512
+    n_layers: 12
+    init_device: cpu
+    expansion_ratio: 4
+    standard_scale_outputs: False
+    transformer_activation: relu
+    n_heads: 8
+    norm_scheme: "pre"
+    use_generative_training: True
+    use_cell_conditioned_generation: False
+    use_glu: False
+    cell_emb_style: cls
+    attn_config:
+      attn_impl: flash
+      use_attn_mask: False
+      attn_type: "grouped_query_attention"
+      kv_nheads: 8
+      attn_pdrop: 0.0
+    norm_config:
+      norm_type: "layernorm"
+      eps: 1.0e-5
+    expression_encoder:
+      input_emb_style: "continuous"
+      dropout: 0.1
+      max_value: 512
+      activation: relu
+      use_norm: True
+    gene_encoder:
+      use_norm: True
+    mvc:
+      arch_style: "inner product"
+      query_activation: "sigmoid"
+      scaled_dot_product: True
+    expression_decoder:
+      n_outputs: 1
+      n_layers: 1
+      activation: "leaky_relu"
+  collator:
+    do_padding: True
+    pad_value: -2
+    do_mlm: True
+    do_binning: True
+    mlm_probability: 0.5
+    mask_value: -1
+    max_length: 1024
+    sampling: True
+    data_style: "both"
+    num_bins: 51
+    right_binning: False
+    use_junk_tokens: False
+  train_loader:
+    dataset:
+      streams:
+        tahoe:
+          remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v2/train/"
+          local: "mds-data-folder/tahoe/train"
+        cellxgene:
+          remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cellxgene_2025_01_21_merged_MDS/train/"
+          local: "mds-data-folder/cellxgene/train"
+        scbasecamp:
+          remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/scbasecamp_2025_02_25_MDS_v2/train/"
+          local: "mds-data-folder/scbasecamp/train"
+      download_timeout: 300
+      allow_unsafe_types: True
+      shuffle: True
+      shuffle_seed: ${global_seed}
+      num_canonical_nodes: 2
+    drop_last: False
+    num_workers: 8
+    pin_memory: True
+    prefetch_factor: 48
+    persistent_workers: True
+  valid_loader:
+    dataset:
+      streams:
+        tahoe:
+          remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v2/valid/"
+          local: "mds-data-folder/tahoe/valid"
+        cellxgene:
+          remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cellxgene_2025_01_21_merged_MDS/valid/"
+          local: "mds-data-folder/cellxgene/valid"
+        scbasecamp:
+          remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/scbasecamp_2025_02_25_MDS_v2/valid/"
+          local: "mds-data-folder/scbasecamp/valid"
+      download_timeout: 300
+      allow_unsafe_types: True
+      shuffle: False
+      shuffle_seed: ${global_seed}
+      num_canonical_nodes: 2
+    drop_last: False
+    num_workers: 8
+    pin_memory: True
+    prefetch_factor: 48
+    persistent_workers: True
+  optimizer:
+    name: decoupled_adamw
+    lr: 3.0e-4
+    betas:
+      - 0.9
+      - 0.95
+    eps: 1.0e-08
+    weight_decay: 1.0e-05
+  scheduler:
+    name: cosine_with_warmup
+    t_warmup: "0.05dur"
+    t_max: "1dur"
+    alpha_f: 0.1
+  algorithms:
+    gradient_clipping:
+      clipping_type: norm
+      clipping_threshold: 1.0
+    low_precision_layernorm: {}
+  precision: amp_bf16
+  eval_interval: "1000ba"
+  eval_subset_num_batches: 100
+  max_duration: "100ba"
+  fsdp_config:
+    sharding_strategy: FULL_SHARD
+    mixed_precision: DEFAULT
+    activation_checkpointing: false
+    activation_checkpointing_reentrant: false
+    activation_cpu_offload: false
+    limit_all_gathers: true
+    verbose: true
+  callbacks:
+    speed_monitor:
+      window_size: 20
+    lr_monitor: {}
+    memory_monitor: {}
+    runtime_estimator: {}
+    cell-classification:
+      cfg:
+        datasets:
+          ccle:
+            train:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/CCLE/ccle.h5ad"
+              local: "cell-classification/ccle.h5ad"
+            cell_type_key: "OncotreeLineage"
+            gene_id_key: "feature_id"
+            seq_len: 8192
+            batch_size: 32
+          tabula:
+            train:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tabula50k/Tabula50k_train.h5ad"
+              local: "cell-classification/Tabula50k_train.h5ad"
+            test:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tabula50k/Tabula50k_test.h5ad"
+              local: "cell-classification/Tabula50k_test.h5ad"
+            cell_type_key: "cell_ontology_class"
+            gene_id_key: "ensembl_id"
+          tahoe:
+            train:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tahoe50k/Tahoe50k_train.h5ad"
+              local: "cell-classification/Tahoe50k_train.h5ad"
+            test:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tahoe50k/Tahoe50k_test.h5ad"
+              local: "cell-classification/Tahoe50k_test.h5ad"
+            cell_type_key: "cell_line"
+            gene_id_key: "ensembl_id"
+          kim:
+            train:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/kim2020/kim_train.h5ad"
+              local: "cell-classification/kim_train.h5ad"
+            test:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/kim2020/kim_test.h5ad"
+              local: "cell-classification/kim_test.h5ad"
+            cell_type_key: "cell_type"
+            gene_id_key: "ensembl_id"
+          zheng:
+            train:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/zheng/zheng_train.h5ad"
+              local: "cell-classification/zheng_train.h5ad"
+            test:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/zheng/zheng_test.h5ad"
+              local: "cell-classification/zheng_test.h5ad"
+            cell_type_key: "cell_type"
+            gene_id_key: "ensembl_id"
+          segerstolpe:
+            train:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/segerstolpe/segerstolpe_train.h5ad"
+              local: "cell-classification/segerstolpe_train.h5ad"
+            test:
+              remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/segerstolpe/segerstolpe_test.h5ad"
+              local: "cell-classification/Segerstolpe_test.h5ad"
+            cell_type_key: "cell_type"
+            gene_id_key: "ensembl_id"
+        classifier_config:
+          max_iter: 5000
+          solver: "lbfgs"
+          multi_class: "multinomial"
+          random_state: 42
+        batch_size: 100
+        seq_len: 2048
+  loggers:
+    wandb:
+      project: vevo-MFM-v2
+      log_artifacts: False
+  save_folder: "s3://vevo-ml-datasets/mosaicfm_v2/models/{run_name}"
+  save_interval: "2000ba"
+  autoresume: True

--- a/mosaicfm/tasks/cell_classification.py
+++ b/mosaicfm/tasks/cell_classification.py
@@ -39,12 +39,12 @@ class CellClassification(Callback):
         self.run_name = state.run_name
 
         for dataset_name, dataset_cfg in self.dataset_registry.items():
-            for split in dataset_cfg:
-                download_file_from_s3_url(
-                    s3_url=dataset_cfg[split]["remote"],
-                    local_file_path=dataset_cfg[split]["local"],
-                )
-
+            for split in ["train", "test"]:
+                if split in dataset_cfg:
+                    download_file_from_s3_url(
+                        s3_url=dataset_cfg[split]["remote"],
+                        local_file_path=dataset_cfg[split]["local"],
+                    )
             self.cell_classfication(dataset_name, logger)
 
     def cell_classfication(self, dataset: str, logger: Logger):
@@ -128,7 +128,7 @@ class CellClassification(Callback):
         # Step 5: compute LISI score for train split
         lisi_score = self.compute_lisi_scores(
             cell_embeddings_train,
-            adata_train.obs["cell_type_label"].values.to_numpy(dtype="str"),
+            adata_train.obs[cell_type_key].values.to_numpy(dtype="str"),
             20,
         )
         logger.log_metrics({f"LISI {dataset}": lisi_score})

--- a/mosaicfm/tasks/cell_classification.py
+++ b/mosaicfm/tasks/cell_classification.py
@@ -119,7 +119,7 @@ class CellClassification(Callback):
             # step 4: calculate and log metrics
             labels_pred = clf.predict(cell_embeddings_test)
             f1 = f1_score(
-                adata_test[cell_type_key].values,
+                adata_test.obs[cell_type_key].values,
                 labels_pred,
                 average="macro",
             )

--- a/mosaicfm/tasks/cell_classification.py
+++ b/mosaicfm/tasks/cell_classification.py
@@ -213,7 +213,8 @@ class CellClassification(Callback):
         adata = adata[~adata.obs[cell_type_key].isna(), :]
 
         if class_idx_to_name is None:
-            # it means provided cell_type_key is already class names, so directly use it as names
+            # We add two columns to the AnnData object: 1.cell_type_names (having class names) and 2.cell_type_label (having class indices)
+            # it means provided cell_type_key column already includes class names, so directly use it as the cell_type_name column
             adata.obs.rename(columns={cell_type_key: "cell_type_names"}, inplace=True)
             # create column of indices for cell types
             adata.obs["cell_type_label"] = (
@@ -223,7 +224,7 @@ class CellClassification(Callback):
                 )
                 .cat.codes
             )
-        else:  # cell_type_key is already a class index
+        else:  # cell_type_key colummn already refers to class indices, so directly use it as the cell_type_label column
             adata.obs["cell_type_names"] = [
                 class_idx_to_name[int(id)] for id in adata.obs[cell_type_key]
             ]

--- a/mosaicfm/tasks/cell_classification.py
+++ b/mosaicfm/tasks/cell_classification.py
@@ -85,15 +85,15 @@ class CellClassification(Callback):
             self.prepare_cell_annotation_data(
                 self.dataset_registry[dataset]["train"]["local"],
                 class_idx_to_name,
-                cell_type_key= self.dataset_registry[dataset].get("cell_type_key"), 
-                gene_name_key= self.dataset_registry[dataset].get("gene_name_key"), 
+                cell_type_key= self.dataset_registry[dataset].get("cell_type_key", "cell_type_label"), 
+                gene_name_key= self.dataset_registry[dataset].get("gene_name_key", "gene_symbols"), 
             )
         )
         adata_test, gene_ids_test, labels_test = self.prepare_cell_annotation_data(
             self.dataset_registry[dataset]["test"]["local"],
             class_idx_to_name,
-            cell_type_key= self.dataset_registry[dataset].get("cell_type_key"), 
-            gene_name_key= self.dataset_registry[dataset].get("gene_name_key"), 
+            cell_type_key= self.dataset_registry[dataset].get("cell_type_key","cell_type_label"), 
+            gene_name_key= self.dataset_registry[dataset].get("gene_name_key", "gene_symbols"), 
         )
 
         # step 2: extract mosaicfm embeddings

--- a/mosaicfm/tasks/cell_classification.py
+++ b/mosaicfm/tasks/cell_classification.py
@@ -139,7 +139,7 @@ class CellClassification(Callback):
         sc.tl.umap(adata_train)
         fig = sc.pl.umap(
             adata_train,
-            color=["cell_type_names"],
+            color=[cell_type_key],
             frameon=False,
             title=[f"{self.run_name} LISI:{lisi_score:.2f} \n {dataset} Dataset"],
             return_fig=True,

--- a/runai/mosaicfm-70m-merged-cell-classification.yaml
+++ b/runai/mosaicfm-70m-merged-cell-classification.yaml
@@ -139,6 +139,15 @@ callbacks:
         remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/vevo_v2_ensembl_to_gene_name.json"
         local: "/vevo/data/datasets/vevo_v2_ensembl_to_gene_name.json"
       datasets:  
+        ccle:
+          train:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/CCLE/CCLE_train.h5ad"
+            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/ccle.h5ad"
+          test:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/CCLE/CCLE_test.h5ad"
+            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/ccle.h5ad"
+          cell_type_key: "OncotreeLineage"
+          gene_name_key: "feature_name"
         tabula:
           train:
             remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tabula50k/Tabula50k_train.h5ad"

--- a/runai/mosaicfm-70m-merged-cell-classification.yaml
+++ b/runai/mosaicfm-70m-merged-cell-classification.yaml
@@ -135,68 +135,61 @@ callbacks:
   runtime_estimator: {}
   cell-classification:
     cfg:
-      ensemble_to_gene_path: 
-        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/vevo_v2_ensembl_to_gene_name.json"
-        local: "/vevo/data/datasets/vevo_v2_ensembl_to_gene_name.json"
       datasets:  
         ccle:
           train:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/CCLE/CCLE_train.h5ad"
-            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/ccle.h5ad"
-          test:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/CCLE/CCLE_test.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/CCLE/CCLE_train.h5ad"
             local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/ccle.h5ad"
           cell_type_key: "OncotreeLineage"
-          gene_name_key: "feature_name"
+          gene_id_key: "feature_id"
+          seq_len: 8192
+          batch_size: 32
         tabula:
           train:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tabula50k/Tabula50k_train.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tabula50k/Tabula50k_train.h5ad"
             local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tabula50k_train.h5ad"
           test:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tabula50k/Tabula50k_test.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tabula50k/Tabula50k_test.h5ad"
             local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tabula50k_test.h5ad"
           cell_type_key: "cell_ontology_class"
-          gene_name_key: "gene_symbol"
+          gene_id_key: "ensembl_id"
         tahoe:
           train:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tahoe50k/Tahoe50k_train.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tahoe50k/Tahoe50k_train.h5ad"
             local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tahoe50k_train.h5ad"
           test:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tahoe50k/Tahoe50k_test.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tahoe50k/Tahoe50k_test.h5ad"
             local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tahoe50k_test.h5ad"
           cell_type_key: "cell_line"
-          gene_name_key: "gene_symbol"
+          gene_id_key: "ensembl_id"
         kim: 
           train:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/kim2020/kim_train.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/kim2020/kim_train.h5ad"
             local: "/vevo/data/datasets/kim2020_lung/kim_train.h5ad"
           test:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/kim2020/kim_test.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/kim2020/kim_test.h5ad"
             local: "/vevo/data/datasets/kim2020_lung/kim_test.h5ad"
           cell_type_key: "cell_type"
+          gene_id_key: "ensembl_id"
         zheng:
           train: 
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/zheng/zheng_train.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/zheng/zheng_train.h5ad"
             local: "/vevo/data/datasets/zheng/zheng_train.h5ad"
           test:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/zheng/zheng_test.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/zheng/zheng_test.h5ad"
             local: "/vevo/data/datasets/zheng/zheng_test.h5ad"
-          class_names:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/zheng/zheng-str_label.npy"
-            local: "/vevo/data/datasets/zheng/zheng-str_label.npy"
-          skip_clustering: True
-        Segerstolpe: 
+          cell_type_key: "cell_type"
+          gene_id_key: "ensembl_id"
+        segerstolpe:
           train:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Segerstolpe/Segerstolpe_train.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Segerstolpe/Segerstolpe_train.h5ad"
             local: "/vevo/data/datasets/Segerstolpe/Segerstolpe_train.h5ad"
           test:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Segerstolpe/Segerstolpe_test.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Segerstolpe/Segerstolpe_test.h5ad"
             local: "/vevo/data/datasets/Segerstolpe/Segerstolpe_test.h5ad"
-          class_names:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Segerstolpe/Segerstolpe-str_label.npy"
-            local: "/vevo/data/datasets/Segerstolpe/Segerstolpe-str_label.npy"
-          skip_clustering: True
-      logistic:
+          cell_type_key: "cell_type"
+          gene_id_key: "ensembl_id"
+      classifier_config:
         max_iter: 5000
         solver: "lbfgs"
         multi_class: "multinomial"

--- a/runai/mosaicfm-70m-merged-cell-classification.yaml
+++ b/runai/mosaicfm-70m-merged-cell-classification.yaml
@@ -8,7 +8,7 @@ vocabulary:
   remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/vevo_v2_vocab.json"
   local: "vocab.json"
 model:
-  name: vevo_scgpt
+  name: mosaicfm
   d_model: 512
   n_layers: 12
   init_device: cpu
@@ -50,7 +50,7 @@ collator:
   do_padding: True
   pad_value: -2
   do_mlm: True
-  do_binning: True #set do_binning=False and log_transform=True and provide target_sum if you want to train with log1p inputs.
+  do_binning: True
   mlm_probability: 0.5
   mask_value: -1
   max_length: 1024
@@ -63,11 +63,14 @@ train_loader:
   dataset:
     streams:
       tahoe:
-        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v1/train/"
-        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/tahoe_merged_MDS/train"
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v2/train/"
+        local: "mds-data-folder/tahoe/train"
       cellxgene:
         remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cellxgene_2025_01_21_merged_MDS/train/"
-        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/cellxgene_merged_MDS/train"
+        local: "mds-data-folder/cellxgene/train"
+      scbasecamp:
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/scbasecamp_2025_02_25_MDS_v2/train/"
+        local: "mds-data-folder/scbasecamp/train"
     download_timeout: 300
     allow_unsafe_types: True
     shuffle: True
@@ -82,11 +85,14 @@ valid_loader:
   dataset:
     streams:
       tahoe:
-        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v1/valid/"
-        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/tahoe_merged_MDS/valid"
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v2/valid/"
+        local: "mds-data-folder/tahoe/valid"
       cellxgene:
         remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cellxgene_2025_01_21_merged_MDS/valid/"
-        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/cellxgene_merged_MDS/valid"
+        local: "mds-data-folder/cellxgene/valid"
+      scbasecamp:
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/scbasecamp_2025_02_25_MDS_v2/valid/"
+        local: "mds-data-folder/scbasecamp/valid"
     download_timeout: 300
     allow_unsafe_types: True
     shuffle: False
@@ -116,9 +122,9 @@ algorithms:
     clipping_threshold: 1.0
   low_precision_layernorm: {}
 precision: amp_bf16
-eval_interval: "1000ba"
+eval_interval: "100ba"
 eval_subset_num_batches: 100
-max_duration: "10ba"
+max_duration: "1000ba"
 fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: DEFAULT
@@ -135,11 +141,11 @@ callbacks:
   runtime_estimator: {}
   cell-classification:
     cfg:
-      datasets:  
+      datasets:
         ccle:
           train:
-            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/CCLE/CCLE_train.h5ad"
-            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/ccle.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/CCLE/ccle.h5ad"
+            local: "cell-classification/ccle.h5ad"
           cell_type_key: "OncotreeLineage"
           gene_id_key: "feature_id"
           seq_len: 8192
@@ -147,46 +153,46 @@ callbacks:
         tabula:
           train:
             remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tabula50k/Tabula50k_train.h5ad"
-            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tabula50k_train.h5ad"
+            local: "cell-classification/Tabula50k_train.h5ad"
           test:
             remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tabula50k/Tabula50k_test.h5ad"
-            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tabula50k_test.h5ad"
+            local: "cell-classification/Tabula50k_test.h5ad"
           cell_type_key: "cell_ontology_class"
           gene_id_key: "ensembl_id"
         tahoe:
           train:
             remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tahoe50k/Tahoe50k_train.h5ad"
-            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tahoe50k_train.h5ad"
+            local: "cell-classification/Tahoe50k_train.h5ad"
           test:
             remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Tahoe50k/Tahoe50k_test.h5ad"
-            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tahoe50k_test.h5ad"
+            local: "cell-classification/Tahoe50k_test.h5ad"
           cell_type_key: "cell_line"
           gene_id_key: "ensembl_id"
-        kim: 
+        kim:
           train:
             remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/kim2020/kim_train.h5ad"
-            local: "/vevo/data/datasets/kim2020_lung/kim_train.h5ad"
+            local: "cell-classification/kim_train.h5ad"
           test:
             remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/kim2020/kim_test.h5ad"
-            local: "/vevo/data/datasets/kim2020_lung/kim_test.h5ad"
+            local: "cell-classification/kim_test.h5ad"
           cell_type_key: "cell_type"
           gene_id_key: "ensembl_id"
         zheng:
-          train: 
+          train:
             remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/zheng/zheng_train.h5ad"
-            local: "/vevo/data/datasets/zheng/zheng_train.h5ad"
+            local: "cell-classification/zheng_train.h5ad"
           test:
             remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/zheng/zheng_test.h5ad"
-            local: "/vevo/data/datasets/zheng/zheng_test.h5ad"
+            local: "cell-classification/zheng_test.h5ad"
           cell_type_key: "cell_type"
           gene_id_key: "ensembl_id"
         segerstolpe:
           train:
-            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Segerstolpe/Segerstolpe_train.h5ad"
-            local: "/vevo/data/datasets/Segerstolpe/Segerstolpe_train.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/segerstolpe/segerstolpe_train.h5ad"
+            local: "cell-classification/segerstolpe_train.h5ad"
           test:
-            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/Segerstolpe/Segerstolpe_test.h5ad"
-            local: "/vevo/data/datasets/Segerstolpe/Segerstolpe_test.h5ad"
+            remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cell_classification_benchmarks/segerstolpe/segerstolpe_test.h5ad"
+            local: "cell-classification/Segerstolpe_test.h5ad"
           cell_type_key: "cell_type"
           gene_id_key: "ensembl_id"
       classifier_config:
@@ -195,12 +201,10 @@ callbacks:
         multi_class: "multinomial"
         random_state: 42
       batch_size: 100
-      seq_len: 2048  
+      seq_len: 2048
 loggers:
   wandb:
     project: vevo-MFM-v2
     log_artifacts: False
-save_folder: "s3://vevo-ml-datasets/vevo-scgpt/models/{run_name}"
+save_folder: "s3://vevo-ml-datasets/mosaicfm_v2/models/{run_name}"
 save_interval: "2000ba"
-run_name: "test"
-save_num_checkpoints_to_keep: 0

--- a/runai/mosaicfm-70m-merged-cell-classification.yaml
+++ b/runai/mosaicfm-70m-merged-cell-classification.yaml
@@ -139,6 +139,24 @@ callbacks:
         remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/vevo_v2_ensembl_to_gene_name.json"
         local: "/vevo/data/datasets/vevo_v2_ensembl_to_gene_name.json"
       datasets:  
+        tabula:
+          train:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tabula50k/Tabula50k_train.h5ad"
+            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tabula50k_train.h5ad"
+          test:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tabula50k/Tabula50k_test.h5ad"
+            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tabula50k_test.h5ad"
+          cell_type_key: "cell_ontology_class"
+          gene_name_key: "gene_symbol"
+        tahoe:
+          train:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tahoe50k/Tahoe50k_train.h5ad"
+            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tahoe50k_train.h5ad"
+          test:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Tahoe50k/Tahoe50k_test.h5ad"
+            local: "/tahoe/gits/z_mosaicfm/debug_notebooks/cell-classification/Tahoe50k_test.h5ad"
+          cell_type_key: "cell_line"
+          gene_name_key: "gene_symbol"
         kim: 
           train:
             remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/kim2020/kim_train.h5ad"
@@ -146,9 +164,7 @@ callbacks:
           test:
             remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/kim2020/kim_test.h5ad"
             local: "/vevo/data/datasets/kim2020_lung/kim_test.h5ad"
-          class_names:
-            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/kim2020/kim-str_label.npy"
-            local: "/vevo/data/datasets/kim2020_lung/kim-str_label.npy"
+          cell_type_key: "cell_type"
         zheng:
           train: 
             remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/zheng/zheng_train.h5ad"
@@ -159,6 +175,7 @@ callbacks:
           class_names:
             remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/zheng/zheng-str_label.npy"
             local: "/vevo/data/datasets/zheng/zheng-str_label.npy"
+          skip_clustering: True
         Segerstolpe: 
           train:
             remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Segerstolpe/Segerstolpe_train.h5ad"
@@ -169,6 +186,7 @@ callbacks:
           class_names:
             remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Segerstolpe/Segerstolpe-str_label.npy"
             local: "/vevo/data/datasets/Segerstolpe/Segerstolpe-str_label.npy"
+          skip_clustering: True
       logistic:
         max_iter: 5000
         solver: "lbfgs"


### PR DESCRIPTION
closes #83 
- Refactored the cell-classification benchmark to read gene and label columns from the config file.
- Made class_names (mapping of class index to names) an optional argument, for datasets that don’t include class names in the AnnData.
- Added a skip_clustering flag to skip clustering and LISI calculation when running into memory issues.
- Added support for more datasets including Tahoe, TabulaSapiens


