### PR TITLE
Added chemical_token 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,6 @@ figures/
 .micromamba/
 scripts/perturbation/debug/
 runai/*/
-vocab.json
+*.json
 debug_notebooks/
 ckpt/

--- a/mosaicfm/data/collator.py
+++ b/mosaicfm/data/collator.py
@@ -92,7 +92,7 @@ class DataCollator(DefaultDataCollator):
         self.data_style = data_style
         self.num_bins = num_bins
         self.right_binning = right_binning
-        self.drug_id = vocab["<drug>"]
+        self.drug_token = vocab["<drug>"]
 
         # filter non_special gene_ids
         gene_to_id = vocab.get_stoi()
@@ -414,8 +414,8 @@ class DataCollator(DefaultDataCollator):
             genes = examples[i]["genes"]
             expressions = examples[i]["expressions"]
 
-            # add drug id at location 1 of genes and expressions (after <cls>)
-            genes = torch.cat((genes[:1], torch.tensor([self.drug_id]), genes[1:]))
+            # add drug token <drug>, and -2 expression at location 1  (after <cls>) of genes and expressions
+            genes = torch.cat((genes[:1], torch.tensor([self.drug_token]), genes[1:]))
             expressions = torch.cat(
                 (expressions[:1], torch.tensor([self.pad_value]), expressions[1:]),
             )

--- a/mosaicfm/data/collator.py
+++ b/mosaicfm/data/collator.py
@@ -1,11 +1,14 @@
 # Copyright (C) Vevo Therapeutics 2024-2025. All rights reserved.
+import json
 from typing import Dict, List, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import torch
+from composer.utils import dist
 from transformers import DefaultDataCollator
 
 from mosaicfm.tokenizer import GeneVocab
+from mosaicfm.utils import download_file_from_s3_url
 
 
 class DataCollator(DefaultDataCollator):
@@ -14,6 +17,7 @@ class DataCollator(DefaultDataCollator):
 
     Args:
         vocab (:obj: GeneVocab): The vocabulary that includes the gene ids, name, special tokens, etc.
+        drug_to_id_path (:obj:`dict`): path to the drug to id .json file.
         do_padding (:obj:`bool`): whether to pad the sequences to the max length.
         unexp_padding (:obj:`bool`): whether to pad the sequences with unexpressed genes. If False it pads with pad token.
         pad_token_id (:obj:`int`, optional): the token id to use for padding.
@@ -50,6 +54,7 @@ class DataCollator(DefaultDataCollator):
     def __init__(
         self,
         vocab: GeneVocab,
+        drug_to_id_path: dict,
         do_padding: bool = True,
         unexp_padding: bool = False,
         pad_token_id: Optional[int] = None,
@@ -87,6 +92,7 @@ class DataCollator(DefaultDataCollator):
         self.data_style = data_style
         self.num_bins = num_bins
         self.right_binning = right_binning
+        self.drug_id = vocab["<drug>"]
 
         # filter non_special gene_ids
         gene_to_id = vocab.get_stoi()
@@ -98,6 +104,18 @@ class DataCollator(DefaultDataCollator):
             ],
         )
         self.vocab = vocab
+
+        # load drug_to_id mapping
+        if dist.get_local_rank() == 0:
+            download_file_from_s3_url(
+                s3_url=drug_to_id_path["remote"],
+                local_file_path=drug_to_id_path["local"],
+            )
+        with dist.local_rank_zero_download_and_wait(drug_to_id_path["local"]):
+            dist.barrier()
+
+        with open(drug_to_id_path["local"]) as f:
+            self.drug_to_id = json.load(f)
 
     def __post_init__(self):
         if self.do_padding:
@@ -149,6 +167,12 @@ class DataCollator(DefaultDataCollator):
             :obj:`Dict[str, torch.Tensor]`: a dict of tensors.
         """
         for example in examples:
+            drug = (
+                example["drug"]
+                if "drug" in example and example["drug"] in self.drug_to_id
+                else "<pad>"
+            )
+            example["drug_id"] = torch.as_tensor(self.drug_to_id[drug], dtype=torch.int)
             if isinstance(example["genes"], list):
                 example["genes"] = torch.as_tensor(example["genes"])
             example["genes"] = torch.squeeze(example["genes"])
@@ -334,7 +358,8 @@ class DataCollator(DefaultDataCollator):
         Each example is like:
             {'id': tensor(184117),
             'genes': tensor([36572, 17868, ..., 17072]),
-            'expressions': tensor([ 0.,  2., ..., 18.])}
+            'expressions': tensor([ 0.,  2., ..., 18.])},
+            'drug_id': tensor(256), id 0 indicates that drug is not available
 
         Args:
             gen_prob (float, optional): the probability of a gene being assigned to
@@ -383,10 +408,19 @@ class DataCollator(DefaultDataCollator):
         padded_gen_genes = []
         padded_gen_expressions = []
         padded_gen_original_exp = []
+        drug_ids = []
+
         for i in range(len(examples)):
             genes = examples[i]["genes"]
             expressions = examples[i]["expressions"]
+
+            # add drug id at location 1 of genes and expressions (after <cls>)
+            genes = torch.cat((genes[:1], torch.tensor([self.drug_id]), genes[1:]))
+            expressions = torch.cat(
+                (expressions[:1], torch.tensor([self.pad_value]), expressions[1:]),
+            )
             original_expressions = expressions.detach().clone()
+
             if self.do_binning:
                 expressions[self.keep_first_n_tokens :] = binning(
                     row=expressions[self.keep_first_n_tokens :],
@@ -453,13 +487,17 @@ class DataCollator(DefaultDataCollator):
             padded_gen_expressions.append(gen_expressions)
             padded_gen_original_exp.append(gen_original_exp)
 
+            # add drug id, id=0 corresponds to <pad> which indicates that drug is not available
+            drug = examples[i]["drug_id"]
+            drug_ids.append(drug)
+
         padded_pcpt_genes = torch.stack(padded_pcpt_genes, dim=0)
         padded_pcpt_expressions = torch.stack(padded_pcpt_expressions, dim=0)
         padded_pcpt_original_exp = torch.stack(padded_pcpt_original_exp, dim=0)
         padded_gen_genes = torch.stack(padded_gen_genes, dim=0)
         padded_gen_expressions = torch.stack(padded_gen_expressions, dim=0)
         padded_gen_original_exp = torch.stack(padded_gen_original_exp, dim=0)
-
+        drug_ids = torch.stack(drug_ids)
         data_dict = {
             "pcpt_gene": padded_pcpt_genes,
             "pcpt_expr": padded_pcpt_expressions,
@@ -467,6 +505,7 @@ class DataCollator(DefaultDataCollator):
             "gen_gene": padded_gen_genes,
             "gen_expr_target": padded_gen_expressions,
             "gen_expr_raw": padded_gen_original_exp,  # "raw" means "not binned"
+            "drug_ids": drug_ids,
         }
 
         return data_dict

--- a/mosaicfm/data/dataloader.py
+++ b/mosaicfm/data/dataloader.py
@@ -61,6 +61,7 @@ def build_dataloader(
 
     collate_fn = DataCollator(
         vocab=vocab,
+        drug_to_id_path=collator_cfg["drug_to_id_path"],
         do_padding=collator_cfg.get("do_padding", True),
         unexp_padding=loader_cfg.get("unexp_padding", False),
         pad_token_id=collator_cfg.pad_token_id,
@@ -76,6 +77,7 @@ def build_dataloader(
         data_style=collator_cfg.data_style,
         num_bins=collator_cfg.get("num_bins", 51),
         right_binning=collator_cfg.get("right_binning", False),
+        keep_first_n_tokens=collator_cfg.get("keep_first_n_tokens", 1),
     )
 
     data_loader = StreamingDataLoader(

--- a/mosaicfm/data/dataloader.py
+++ b/mosaicfm/data/dataloader.py
@@ -61,7 +61,7 @@ def build_dataloader(
 
     collate_fn = DataCollator(
         vocab=vocab,
-        drug_to_id_path=collator_cfg["drug_to_id_path"],
+        drug_to_id_path=collator_cfg.get("drug_to_id_path", None),
         do_padding=collator_cfg.get("do_padding", True),
         unexp_padding=loader_cfg.get("unexp_padding", False),
         pad_token_id=collator_cfg.pad_token_id,
@@ -78,6 +78,7 @@ def build_dataloader(
         num_bins=collator_cfg.get("num_bins", 51),
         right_binning=collator_cfg.get("right_binning", False),
         keep_first_n_tokens=collator_cfg.get("keep_first_n_tokens", 1),
+        use_chem_token=collator_cfg.get("use_chem_token", False),
     )
 
     data_loader = StreamingDataLoader(

--- a/mosaicfm/model/blocks.py
+++ b/mosaicfm/model/blocks.py
@@ -378,9 +378,10 @@ class GeneEncoder(nn.Module):
             x = self.enc_norm(
                 x,
             )  # Norm for embedding is not used when using pre-norm transformer.
-        
+
         return x
-    
+
+
 class ChemEncoder(nn.Module):
     def __init__(
         self,
@@ -390,7 +391,6 @@ class ChemEncoder(nn.Module):
         activation: str = "leaky_relu",
         use_norm: bool = True,
         freeze: bool = False,
-
     ):
         super().__init__()
 
@@ -406,7 +406,11 @@ class ChemEncoder(nn.Module):
         drug_fps = torch.as_tensor(np.load(drug_fps_path["local"]), dtype=torch.float32)
         embedding_dim = drug_fps.shape[1]
 
-        self.embedding = nn.Embedding.from_pretrained(drug_fps, padding_idx=padding_idx, freeze=freeze)
+        self.embedding = nn.Embedding.from_pretrained(
+            drug_fps,
+            padding_idx=padding_idx,
+            freeze=freeze,
+        )
         self.fc = nn.Linear(embedding_dim, d_out)
         self.activation = resolve_ffn_act_fn({"name": activation})
         self.use_norm = use_norm

--- a/mosaicfm/model/blocks.py
+++ b/mosaicfm/model/blocks.py
@@ -413,6 +413,8 @@ class ChemEncoder(nn.Module):
         )
         self.fc = nn.Linear(embedding_dim, d_out)
         self.activation = resolve_ffn_act_fn({"name": activation})
+        self.proj = nn.Linear(d_out, d_out)
+
         self.use_norm = use_norm
         if self.use_norm:
             self.norm = nn.LayerNorm(d_out)
@@ -420,6 +422,8 @@ class ChemEncoder(nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         x = self.embedding(x)  # (batch, d_out)
         x = self.activation(self.fc(x))
+        x = self.proj(x)  # (batch, d_out)
+        
         if self.use_norm:
             x = self.norm(x)
         return x

--- a/mosaicfm/model/blocks.py
+++ b/mosaicfm/model/blocks.py
@@ -423,7 +423,7 @@ class ChemEncoder(nn.Module):
         x = self.embedding(x)  # (batch, d_out)
         x = self.activation(self.fc(x))
         x = self.proj(x)  # (batch, d_out)
-        
+
         if self.use_norm:
             x = self.norm(x)
         return x

--- a/mosaicfm/model/model.py
+++ b/mosaicfm/model/model.py
@@ -46,6 +46,14 @@ class SCGPTModel(nn.Module):
         self.norm_scheme = model_config.get("norm_scheme", "pre")
         self.transformer_activation = model_config.get("transformer_activation", "gelu")
         self.use_generative_training = model_config.get("use_generative_training", True)
+        self.use_chem_token = collator_config.get("use_chem_token", False)
+        assert (
+            not self.use_chem_token or "chemical_encoder" in model_config
+        ), "If use_chem_token is set to True, chemical_encoder submodule needs to be specified!"
+        assert (
+            "chemical_encoder" not in model_config or self.use_chem_token
+        ), "If chemical_encoder submodule is specified, use_chem_token needs to be set to True!"
+
         self.init_device = model_config.get("init_device", "cpu")
         if self.init_device == "mixed":
             if dist.get_local_rank() == 0:
@@ -104,18 +112,20 @@ class SCGPTModel(nn.Module):
         else:
             raise ValueError(f"Unknown input_emb_style: {self.input_emb_style}")
 
-        chem_encoder_config = model_config.chemical_encoder
-        self.chem_encoder = ChemEncoder(
-            drug_fps_path=chem_encoder_config.get("drug_fps_path"),
-            d_out=self.d_model,
-            padding_idx=chem_encoder_config.get("padding_idx", 0),
-            activation=chem_encoder_config.get("activate", "leaky_relu"),
-            freeze=chem_encoder_config.get("freeze", False),
-        )
+        if self.use_chem_token:
+            chem_encoder_config = model_config.chemical_encoder
+            self.chem_encoder = ChemEncoder(
+                drug_fps_path=chem_encoder_config.get("drug_fps_path"),
+                d_out=self.d_model,
+                padding_idx=chem_encoder_config.get("padding_idx", 0),
+                activation=chem_encoder_config.get("activate", "leaky_relu"),
+                freeze=chem_encoder_config.get("freeze", False),
+            )
 
-        # Disable re-inititialization for the entire subtree of chem_encoder
-        for module in self.chem_encoder.modules():
-            module.skip_init = True
+            # Disable re-inititialization for the entire subtree of chem_encoder
+            # so that the Embedding layer is correctly initialized with morgan/ibm embeddings.
+            for module in self.chem_encoder.modules():
+                module.skip_init = True
 
         encoder_layers = SCGPTBlock(
             d_model=self.d_model,
@@ -195,19 +205,22 @@ class SCGPTModel(nn.Module):
         pcpt_genes: Tensor,
         pcpt_values: Tensor,
         pcpt_key_padding_mask: Tensor,
-        drug_ids: Tensor,
         gen_genes: Tensor,
         gen_key_padding_mask: Tensor,
         input_cell_emb: Optional[Tensor] = None,  # (batch, seq_len, embsize)
+        drug_ids: Optional[
+            Tensor
+        ] = None,  # drug_ids is None if use_chem_token is set to False
     ) -> Tuple[Tensor, Tensor]:
 
         pcpt_token_embs = self.gene_encoder(pcpt_genes)  # (batch, pcpt_len, embsize)
         pcpt_values = self.expression_encoder(pcpt_values)  # (batch, pcpt_len, embsize)
         pcpt_total_embs = pcpt_token_embs + pcpt_values  # (batch, pcpt_len, embsize)
 
-        # calculate chemical embedding and put it in its correct place (after <cls>)
-        drug_embs = self.chem_encoder(drug_ids)  # (batch, embsize)
-        pcpt_total_embs[:, 1, :] = drug_embs  # (batch, pcpt_len, embsize)
+        if self.use_chem_token:
+            # calculate chemical embedding and put it in its correct place (after <cls>)
+            drug_embs = self.chem_encoder(drug_ids)  # (batch, embsize)
+            pcpt_total_embs[:, 1, :] = drug_embs  # (batch, pcpt_len, embsize)
 
         if gen_genes is not None:
             gen_token_embs = self.gene_encoder(gen_genes)  # (batch, gen_len, embsize)
@@ -307,12 +320,12 @@ class SCGPTModel(nn.Module):
         pcpt_genes: Tensor,
         pcpt_values: Tensor,
         pcpt_key_padding_mask: Tensor,
-        drug_ids: Tensor,
         gen_genes: Tensor,
         gen_key_padding_mask: Tensor,
         CLS: bool = False,
         MVC: bool = False,
         input_cell_emb: Optional[Tensor] = None,
+        drug_ids: Optional[Tensor] = None,
     ) -> Mapping[str, Tensor]:
         """
         Args:
@@ -322,14 +335,14 @@ class SCGPTModel(nn.Module):
                 [batch_size, seq_len]
             pcpt_key_padding_mask (:obj:`Tensor`): mask for pcpt_genes, shape
                 [batch_size, seq_len]
-            drug_ids (:obj:`Tensor`): drug ids corresponding to chem_encoder embedding layer, shape
-                [batch_size]
             gen_genes (:obj:`Tensor`): token ids of the generative part, shape
                 [batch_size, seq_len]
             gen_key_padding_mask (:obj:`Tensor`): mask for gen_genes, shape
                 [batch_size, seq_len]
             input_cell_emb (:obj:`Tensor`): cell embeddings, shape [batch_size,
                 embsize]
+            drug_ids (:obj:`Tensor`): drug ids corresponding to chem_encoder embedding layer, shape
+                [batch_size]
 
         Returns:
             :obj:`Mapping[str, Tensor]`:
@@ -342,10 +355,10 @@ class SCGPTModel(nn.Module):
             pcpt_genes,
             pcpt_values,
             pcpt_key_padding_mask,
-            drug_ids,
             gen_genes,
             gen_key_padding_mask,
             input_cell_emb=input_cell_emb,
+            drug_ids=drug_ids,
         )
         if gen_output is None:  # type: ignore
             transformer_output = pcpt_output
@@ -451,16 +464,18 @@ class ComposerSCGPTModel(ComposerModel):
         pcpt_gene = batch["pcpt_gene"]
         pcpt_expr = batch["pcpt_expr"]
         pcpt_key_padding_mask = ~pcpt_gene.eq(self.pad_token_id)
-        drug_ids = batch["drug_ids"]
+        drug_ids = (
+            batch["drug_ids"] if "drug_ids" in batch else None
+        )  # drug_ids is None if use_chem_token is set to False
         gen_gene = batch["gen_gene"]
         gen_key_padding_mask = ~gen_gene.eq(self.pad_token_id)
         output_dict = self.model(
             pcpt_gene,
             pcpt_expr,
             pcpt_key_padding_mask,
-            drug_ids,
             gen_gene,
             gen_key_padding_mask,
+            drug_ids=drug_ids,
             MVC=True,
             generative_training=True,
         )
@@ -470,9 +485,9 @@ class ComposerSCGPTModel(ComposerModel):
                 pcpt_gene,
                 pcpt_expr,
                 pcpt_key_padding_mask,
-                drug_ids,
                 gen_gene,
                 gen_key_padding_mask,
+                drug_ids=drug_ids,
                 MVC=False,
                 input_cell_emb=previous_cell_embs,
                 generative_training=True,

--- a/mosaicfm/model/model.py
+++ b/mosaicfm/model/model.py
@@ -118,7 +118,7 @@ class SCGPTModel(nn.Module):
                 drug_fps_path=chem_encoder_config.get("drug_fps_path"),
                 d_out=self.d_model,
                 padding_idx=chem_encoder_config.get("padding_idx", 0),
-                activation=chem_encoder_config.get("activate", "leaky_relu"),
+                activation=chem_encoder_config.get("activation", "leaky_relu"),
                 freeze=chem_encoder_config.get("freeze", False),
             )
 

--- a/mosaicfm/model/model.py
+++ b/mosaicfm/model/model.py
@@ -159,11 +159,10 @@ class SCGPTModel(nn.Module):
             )
             self.apply(self.param_init_fn)
 
-
     def param_init_fn(self, module: nn.Module):
-        #skip initialization for modules that has skip_init=Tru
-        if hasattr(module, 'skip_init') and module.skip_init:
-            log.info("Skipping re-initializing for", module._get_name())    
+        # skip initialization for modules that has skip_init=True
+        if hasattr(module, "skip_init") and module.skip_init:
+            log.info(f"Skipping re-initializing for {module._get_name()}")
             return
         init_fn_name = self.init_config["name"]
         param_init_fns.get(init_fn_name)(

--- a/mosaicfm/model/model.py
+++ b/mosaicfm/model/model.py
@@ -196,7 +196,7 @@ class SCGPTModel(nn.Module):
         pcpt_values = self.expression_encoder(pcpt_values)  # (batch, pcpt_len, embsize)
         pcpt_total_embs = pcpt_token_embs + pcpt_values  # (batch, pcpt_len, embsize)
 
-        # calculate chemical embedding and append it to the end of pcpt tokens
+        # calculate chemical embedding and put it in its correct place (after <cls>)
         drug_embs = self.chem_encoder(drug_ids)  # (batch, embsize)
         pcpt_total_embs[:, 1, :] = drug_embs  # (batch, pcpt_len, embsize)
 

--- a/mosaicfm/tasks/emb_extractor.py
+++ b/mosaicfm/tasks/emb_extractor.py
@@ -69,7 +69,7 @@ def get_batch_embeddings(
     )
     collate_fn = DataCollator(
         vocab=vocab,
-        drug_to_id_path=collator_cfg.get("drug_to_id_path"),
+        drug_to_id_path=collator_cfg.get("drug_to_id_path", None),
         do_padding=collator_cfg.get("do_padding", True),
         unexp_padding=False,  # Disable padding with random unexpressed genes for inference
         pad_token_id=collator_cfg.pad_token_id,
@@ -86,6 +86,7 @@ def get_batch_embeddings(
         num_bins=collator_cfg.get("num_bins", 51),
         right_binning=collator_cfg.get("right_binning", False),
         keep_first_n_tokens=collator_cfg.get("keep_first_n_tokens", 1),
+        use_chem_token=collator_cfg.get("use_chem_token", False),
     )
     data_loader = torch.utils.data.DataLoader(
         dataset,

--- a/mosaicfm/tasks/emb_extractor.py
+++ b/mosaicfm/tasks/emb_extractor.py
@@ -69,6 +69,7 @@ def get_batch_embeddings(
     )
     collate_fn = DataCollator(
         vocab=vocab,
+        drug_to_id_path=collator_cfg.get("drug_to_id_path"),
         do_padding=collator_cfg.get("do_padding", True),
         unexp_padding=False,  # Disable padding with random unexpressed genes for inference
         pad_token_id=collator_cfg.pad_token_id,
@@ -84,6 +85,7 @@ def get_batch_embeddings(
         data_style="pcpt",  # Disable splitting of genes into pcpt and gen for inference
         num_bins=collator_cfg.get("num_bins", 51),
         right_binning=collator_cfg.get("right_binning", False),
+        keep_first_n_tokens=collator_cfg.get("keep_first_n_tokens", 1),
     )
     data_loader = torch.utils.data.DataLoader(
         dataset,

--- a/runai/mosaicfm-70m-merged-flash-chem.yaml
+++ b/runai/mosaicfm-70m-merged-flash-chem.yaml
@@ -1,0 +1,153 @@
+global_seed: 777
+seed: ${global_seed}
+device_train_batch_size: 400
+global_train_batch_size: 4800
+device_eval_batch_size: 400
+device_train_microbatch_size: 400
+vocabulary:
+  remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/vevo_v2_vocab.json"
+  local: "vocab.json"
+model:
+  name: vevo_scgpt
+  d_model: 512
+  n_layers: 12
+  init_device: cpu
+  expansion_ratio: 4
+  standard_scale_outputs: False
+  transformer_activation: relu
+  n_heads: 8
+  norm_scheme: "pre"
+  use_generative_training: True
+  use_cell_conditioned_generation: False
+  use_glu: False
+  cell_emb_style: cls
+  attn_config:
+    attn_impl: flash
+    attn_type: "grouped_query_attention"
+    kv_nheads: 8
+    attn_pdrop: 0.0
+    use_attn_mask: False
+  norm_config:
+    norm_type: "layernorm"
+    eps: 1.0e-5
+  expression_encoder:
+    input_emb_style: "continuous"
+    dropout: 0.1
+    max_value: 512
+    activation: relu
+    use_norm: True
+  gene_encoder:
+    use_norm: True
+  mvc:
+    arch_style: "inner product"
+    query_activation: "sigmoid"
+    scaled_dot_product: True
+  expression_decoder:
+    n_outputs: 1
+    n_layers: 1
+    activation: "leaky_relu"
+  chemical_encoder:
+    drug_fps_path:
+      remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/drug_fps.npy"
+      local: "/vevo/gits/mosaicfm/debug_notebooks/morgan/drug_fps.npy"
+    activation: "leaky_relu"
+    padding_idx: 0
+collator:
+  do_padding: True
+  pad_value: -2
+  do_mlm: True
+  do_binning: True
+  mlm_probability: 0.5
+  mask_value: -1
+  max_length: 1024
+  sampling: True
+  data_style: "both"
+  num_bins: 51
+  right_binning: False
+  use_junk_tokens: False
+  drug_to_id_path:
+    remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/drug_to_id.json"
+    local: "/vevo/gits/mosaicfm/debug_notebooks/morgan/drug_to_id.json"
+  keep_first_n_tokens: 2
+train_loader:
+  dataset:
+    streams:
+      tahoe:
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v2/train/"
+        local: "/vevo/data/tahoe_merged_MDS_v2/train/"
+      cellxgene:
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cellxgene_2025_01_21_merged_MDS/train/"
+        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/cellxgene_merged_MDS/train/"
+    download_timeout: 300
+    allow_unsafe_types: True
+    shuffle: True
+    shuffle_seed: ${global_seed}
+    num_canonical_nodes: 2
+  drop_last: False
+  num_workers: 8
+  pin_memory: True
+  prefetch_factor: 48
+  persistent_workers: True
+valid_loader:
+  dataset:
+    streams:
+      tahoe:
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/tahoe_100m_MDS_v2/valid/"
+        local: "/vevo/data/tahoe_merged_MDS_v2/valid/"
+      cellxgene:
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/cellxgene_2025_01_21_merged_MDS/valid/"
+        local: "/vevo/mosaicfm/datasets/vevo_merged_jan_2025/cellxgene_merged_MDS/valid/"
+    download_timeout: 300
+    allow_unsafe_types: True
+    shuffle: False
+    shuffle_seed: ${global_seed}
+    num_canonical_nodes: 2
+  drop_last: False
+  num_workers: 8
+  pin_memory: True
+  prefetch_factor: 48
+  persistent_workers: True
+optimizer:
+  name: decoupled_adamw
+  lr: 3.0e-4
+  betas:
+    - 0.9
+    - 0.95
+  eps: 1.0e-08
+  weight_decay: 1.0e-05
+scheduler:
+  name: cosine_with_warmup
+  t_warmup: "0.05dur"
+  t_max: "1dur"
+  alpha_f: 0.1
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
+  low_precision_layernorm: {}
+precision: amp_bf16
+eval_interval: "1000ba"
+eval_subset_num_batches: 100
+max_duration: "1ep"
+fsdp_config:
+  sharding_strategy: FULL_SHARD #in case of problem set to NO_SHARD
+  mixed_precision: DEFAULT
+  activation_checkpointing: false
+  activation_checkpointing_reentrant: false
+  activation_cpu_offload: false
+  limit_all_gathers: true
+  verbose: true
+callbacks:
+  speed_monitor:
+    window_size: 20
+  lr_monitor: {}
+  memory_monitor: {}
+  runtime_estimator: {}
+loggers:
+  wandb:
+    project: vevo-MFM-v2
+    log_artifacts: False
+save_folder: "s3://vevo-ml-datasets/vevo-scgpt/models/{run_name}"
+save_interval: "2000ba"
+autoresume: False
+run_name: "mosaicfm-70m-merged-flash-chem"

--- a/runai/mosaicfm-70m-merged-flash-chem.yaml
+++ b/runai/mosaicfm-70m-merged-flash-chem.yaml
@@ -14,7 +14,7 @@ model:
   init_device: cpu
   expansion_ratio: 4
   standard_scale_outputs: False
-  transformer_activation: relu
+  transformer_activation: gelu
   n_heads: 8
   norm_scheme: "pre"
   use_generative_training: True
@@ -24,9 +24,9 @@ model:
   attn_config:
     attn_impl: flash
     attn_type: "grouped_query_attention"
+    use_attn_mask: False
     kv_nheads: 8
     attn_pdrop: 0.0
-    use_attn_mask: False
   norm_config:
     norm_type: "layernorm"
     eps: 1.0e-5
@@ -34,7 +34,7 @@ model:
     input_emb_style: "continuous"
     dropout: 0.1
     max_value: 512
-    activation: relu
+    activation: gelu
     use_norm: True
   gene_encoder:
     use_norm: True
@@ -45,12 +45,12 @@ model:
   expression_decoder:
     n_outputs: 1
     n_layers: 1
-    activation: "leaky_relu"
+    activation: "gelu"
   chemical_encoder:
     drug_fps_path:
-      remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/drug_fps.npy"
-      local: "/vevo/gits/mosaicfm/debug_notebooks/morgan/drug_fps.npy"
-    activation: "leaky_relu"
+      remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/drug_fps_pad.npy"
+      local: "drug_fps.npy"
+    activation: "gelu"
     padding_idx: 0
     freeze: False
 collator:
@@ -66,9 +66,10 @@ collator:
   num_bins: 51
   right_binning: False
   use_junk_tokens: False
+  use_chem_token: True
   drug_to_id_path:
-    remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/drug_to_id.json"
-    local: "/vevo/gits/mosaicfm/debug_notebooks/morgan/drug_to_id.json"
+    remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/drug_to_id_pad.json"
+    local: "drug_to_id_pad.json"
   keep_first_n_tokens: 2
 train_loader:
   dataset:
@@ -110,7 +111,7 @@ valid_loader:
   persistent_workers: True
 optimizer:
   name: decoupled_adamw
-  lr: 3.0e-4
+  lr: 1.0e-3
   betas:
     - 0.9
     - 0.95
@@ -144,6 +145,66 @@ callbacks:
   lr_monitor: {}
   memory_monitor: {}
   runtime_estimator: {}
+  marginal-essentiality:
+    cfg:
+      batch_size: 32
+      seq_len: 8192
+      adata:
+        remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/marginal-essentiality/ccle.h5ad"
+        local: "ccle.h5ad"
+        gene_column: "feature_id"
+      labels:
+        remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/marginal-essentiality/labels.csv"
+        local: "labels.csv"
+        gene_column: "gene_id"
+        label_column: "essential"
+      classifier:
+        n_jobs: 32
+        test_size: 0.2
+        random_state: 42
+  cell-classification:
+    cfg:
+      ensemble_to_gene_path: 
+        remote: "s3://vevo-ml-datasets/mosaicfm_v2/datasets/vevo_v2_ensembl_to_gene_name.json"
+        local: "vevo_v2_ensembl_to_gene_name.json"
+      datasets:  
+        kim: 
+          train:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/kim2020/kim_train.h5ad"
+            local: "mds-data-folder/kim_train.h5ad"
+          test:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/kim2020/kim_test.h5ad"
+            local: "mds-data-folder/kim_test.h5ad"
+          class_names:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/kim2020/kim-str_label.npy"
+            local: "mds-data-folder/kim-str_label.npy"          
+        zheng:
+          train: 
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/zheng/zheng_train.h5ad"
+            local: "mds-data-folder/zheng_train.h5ad"
+          test:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/zheng/zheng_test.h5ad"
+            local: "mds-data-folder/zheng_test.h5ad"
+          class_names:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/zheng/zheng-str_label.npy"
+            local: "mds-data-folder/zheng-str_label.npy"
+        Segerstolpe: 
+          train:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Segerstolpe/Segerstolpe_train.h5ad"
+            local: "mds-data-folder/Segerstolpe_train.h5ad"
+          test:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Segerstolpe/Segerstolpe_test.h5ad"
+            local: "mds-data-folder/Segerstolpe_test.h5ad"
+          class_names:
+            remote: "s3://vevo-ml-datasets/vevo-scgpt/datasets/scgpt_benchmarks/Segerstolpe/Segerstolpe-str_label.npy"
+            local: "mds-data-folder/Segerstolpe-str_label.npy"
+      logistic:
+        max_iter: 5000
+        solver: "lbfgs"
+        multi_class: "multinomial"
+        random_state: 42
+      batch_size: 100
+      seq_len: 2048    
 loggers:
   wandb:
     project: vevo-MFM-v2

--- a/runai/mosaicfm-70m-merged-flash-chem.yaml
+++ b/runai/mosaicfm-70m-merged-flash-chem.yaml
@@ -52,6 +52,7 @@ model:
       local: "/vevo/gits/mosaicfm/debug_notebooks/morgan/drug_fps.npy"
     activation: "leaky_relu"
     padding_idx: 0
+    freeze: False
 collator:
   do_padding: True
   pad_value: -2

--- a/scripts/drug-embedding/generate_fps.ipynb
+++ b/scripts/drug-embedding/generate_fps.ipynb
@@ -1,0 +1,382 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright (C) Vevo Therapeutics 2024-2025. All rights reserved.\n",
+    "import copy\n",
+    "import numpy as np\n",
+    "from rdkit import Chem\n",
+    "from rdkit.Chem import AllChem\n",
+    "from rdkit.DataStructs import ConvertToNumpyArray\n",
+    "from tqdm.auto import tqdm\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_fingerprints(smiles_list: list, fingerprint_type: str = \"morgan\", radius: int = 2) -> np.ndarray:\n",
+    "    \"\"\"Generate fingerprints for a list of SMILES strings.\"\"\"\n",
+    "    print(f\"Generating {fingerprint_type} fingerprints for {len(smiles_list)} SMILES strings.\")\n",
+    "    fingerprints = []\n",
+    "    for smiles in tqdm(smiles_list, desc=\"Generating fingerprints\"):\n",
+    "        mol = Chem.MolFromSmiles(smiles)\n",
+    "        if mol is None:\n",
+    "            fingerprints.append(None)\n",
+    "            continue\n",
+    "        if fingerprint_type == \"morgan\":\n",
+    "            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius)\n",
+    "        else:\n",
+    "            raise ValueError(f\"Unknown fingerprint type: {fingerprint_type}\")\n",
+    "        fingerprints.append(np.array(fp.ToList()))\n",
+    "    print(\"Fingerprint generation complete.\")\n",
+    "    return np.array(fingerprints)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_fingerprints_np(smiles_list: list, radius: int = 2, nBits: int = 2048) -> np.ndarray:\n",
+    "    \"\"\"Generate fingerprints for a list of SMILES strings using a NumPy array allocation.\"\"\"\n",
+    "    print(f\"Generating Morgan fingerprints for {len(smiles_list)} SMILES strings.\")\n",
+    "    fingerprints = np.zeros((len(smiles_list), nBits), dtype=int)\n",
+    "    for i, smiles in enumerate(tqdm(smiles_list, desc=\"Generating fingerprints\")):\n",
+    "        mol = Chem.MolFromSmiles(smiles)\n",
+    "        if mol is None:\n",
+    "            # Here you might want to set a row of NaNs or zeros to indicate failure\n",
+    "            fingerprints[i, :] = np.nan\n",
+    "            continue\n",
+    "        fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nBits)\n",
+    "        ConvertToNumpyArray(fp, fingerprints[i])\n",
+    "    print(\"Fingerprint generation complete.\")\n",
+    "    return fingerprints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "drug_metadata =  load_dataset(\"vevotx/Tahoe-100M\",\"drug_metadata\", split=\"train\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Dataset({\n",
+       "    features: ['drug', 'targets', 'moa-broad', 'moa-fine', 'human-approved', 'clinical-trials', 'gpt-notes-approval', 'canonical_smiles', 'pubchem_cid'],\n",
+       "    num_rows: 379\n",
+       "})"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drug_metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "drugs = drug_metadata[\"drug\"] #None in two places, 379 unique\n",
+    "cid = drug_metadata[\"pubchem_cid\"] #None in two places, 377 unique\n",
+    "smiles = drug_metadata[\"canonical_smiles\"] #identical in two places and none in two places"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "378 {'<pad>': 0, 'Talc': 1, 'Bortezomib': 2, 'Ixazomib': 3, 'Ixazomib citrate': 4, 'Lactate (calcium)': 5, 'Bisoprolol (hemifumarate)': 6, 'Fumaric acid': 7, 'Hydroxyurea': 8, 'L-Eflornithine (monohydrochloride)': 9, 'Cysteamine (hydrochloride)': 10, 'Darinaparsin': 11, 'Entecavir (monohydrate)': 12, 'Allantoin': 13, '5-Fluorouracil': 14, 'L-Thyroxine (sodium salt pentahydrate)': 15, 'Gallic acid': 16, 'Gallic acid (hydrate)': 17, 'ERK5-IN-2': 18, 'Vilanterol': 19, 'Niclosamide (olamine)': 20, 'Norepinephrine (hydrochloride)': 21, 'Triclosan': 22, 'Mitoxantrone (dihydrochloride)': 23, 'Pentamidine (isethionate)': 24, 'Folic acid': 25, 'Balsalazide (sodium hydrate)': 26, 'Resveratrol': 27, 'PF-06260933': 28, 'Daidzin': 29, 'Pemetrexed': 30, 'Econazole': 31, 'XRK3F2': 32, 'Arbutin': 33, 'Tucidinostat': 34, 'Pexidartinib (hydrochloride)': 35, 'Sodium Salicylate': 36, 'Salicylic acid': 37, 'Ataluren': 38, '4EGI-1': 39, 'Clotrimazole': 40, 'Phenytoin (sodium)': 41, 'SBI-0640756': 42, 'Oxaprozin': 43, 'Baicalin': 44, 'Belinostat': 45, 'Carbamazepine': 46, 'HI-TOPK-032': 47, '8-Hydroxyquinoline': 48, 'Riluzole hydrochloride': 49, 'Minodronic acid': 50, 'GSK1059615': 51, 'Gemcitabine': 52, 'Cytarabine': 53, 'Cytarabine (hydrochloride)': 54, 'Uridine': 55, 'Selinexor': 56, 'Furosemide': 57, 'Adenosine': 58, '5-Azacytidine': 59, 'Clofarabine': 60, 'Adenine': 61, 'Allopurinol': 62, 'Trifluridine': 63, 'Brivudine': 64, 'Idoxuridine': 65, 'Decitabine': 66, 'Lenalidomide (hemihydrate)': 67, 'DT-061': 68, 'BAY1125976': 69, 'Larotrectinib': 70, 'Larotrectinib sulfate': 71, 'olaparib': 72, 'Filgotinib': 73, 'ULK-101': 74, 'Oxaliplatin': 75, 'Cilostazol': 76, 'LY2090314': 77, 'Cobimetinib': 78, 'Asciminib': 79, 'Capivasertib': 80, 'Penfluridol': 81, 'Lonafarnib': 82, 'Pimozide': 83, 'Clonidine (hydrochloride)': 84, 'Brimonidine': 85, 'AT7519': 86, 'Hydroxyfasudil': 87, 'BI-78D3': 88, 'ETC-206': 89, 'LJI308': 90, 'Bimiralisib': 91, 'Bentamapimod': 92, 'Lipoic acid': 93, 'Peretinoin': 94, 'IQ 1': 95, 'Acetohexamide': 96, 'Pentoxifylline': 97, 'DTP3': 98, 'Acetazolamide': 99, 'Pasireotide (acetate)': 100, 'Chlorhexidine (diacetate)': 101, 'Aspirin': 102, 'Abiraterone acetate': 103, 'Sivelestat (sodium tetrahydrate)': 104, 'Atazanavir (sulfate)': 105, 'Terfenadine': 106, 'Bosentan (hydrate)': 107, 'Dabrafenib': 108, 'Ralimetinib dimesylate': 109, 'Saquinavir': 110, 'Pentagastrin': 111, 'Anastrozole': 112, 'Harringtonine': 113, 'Homoharringtonine': 114, 'Flutamide': 115, 'Thymopentin': 116, 'Aliskiren': 117, 'Verapamil': 118, '(R)-Verapamil (hydrochloride)': 119, 'Ritonavir': 120, 'Goserelin (acetate)': 121, 'Bestatin': 122, 'Bestatin (hydrochloride)': 123, 'Imiquimod (maleate)': 124, 'Imiquimod (hydrochloride)': 125, 'Encorafenib': 126, 'AZD1390': 127, 'Sapanisertib': 128, 'Torkinib': 129, 'Belumosudil': 130, 'Belumosudil (mesylate)': 131, 'Esmolol (hydrochloride)': 132, 'Erdafitinib': 133, 'Malotilate': 134, 'Fenofibrate': 135, 'MK-8353': 136, 'crizotinib': 137, '(S)-Crizotinib': 138, 'Crizotinib (hydrochloride)': 139, 'Aprepitant': 140, 'Cinacalcet': 141, 'Naproxen': 142, 'Zileuton': 143, 'Voriconazole': 144, 'Carbidopa (monohydrate)': 145, 'Silodosin': 146, 'Darolutamide': 147, 'Benproperine (phosphate)': 148, 'Bicalutamide': 149, 'Captopril': 150, 'Tirabrutinib': 151, 'Tirabrutinib (hydrochloride)': 152, 'Mifepristone': 153, 'Fostamatinib (disodium hexahydrate)': 154, 'Temuterkib': 155, 'Tetracycline (hydrochloride)': 156, 'Glycyrrhizic acid': 157, 'Diammonium Glycyrrhizinate': 158, 'venetoclax': 159, 'Delamanid': 160, 'Dexmedetomidine': 161, 'Ranolazine': 162, 'Lopinavir': 163, 'Valdecoxib': 164, 'Cloxacillin (sodium)': 165, 'Elagolix sodium': 166, 'palbociclib': 167, 'Retinoic acid': 168, 'PH-797804': 169, 'Ponatinib': 170, 'Radotinib': 171, 'NVP-BHG712': 172, 'Canagliflozin': 173, 'MK-3903': 174, 'EX229': 175, 'Flumatinib (mesylate)': 176, 'Tucatinib': 177, 'Trimetrexate': 178, 'APTO-253': 179, 'Vitamin K4': 180, 'Panobinostat': 181, 'Rimonabant': 182, 'Rimonabant (Hydrochloride)': 183, 'Ligustrazine': 184, 'Sulfisoxazole': 185, 'Alpelisib': 186, 'Trametinib': 187, 'Nevirapine': 188, 'Tomivosertib': 189, 'Paclitaxel': 190, 'Docetaxel': 191, 'Docetaxel (Trihydrate)': 192, 'Roxadustat': 193, 'Thymol': 194, 'Gemfibrozil': 195, 'Vortioxetine': 196, 'OTS514': 197, 'Pralsetinib': 198, 'Menadione': 199, 'Ciclopirox': 200, 'Methylthiouracil': 201, 'Tolcapone': 202, 'Tolmetin': 203, 'Celecoxib': 204, 'S-Adenosyl-L-methionine (disulfate tosylate)': 205, 'Lapatinib ditosylate': 206, 'LY-2584702 (tosylate salt)': 207, 'Edoxaban (tosylate monohydrate)': 208, 'Lumateperone (tosylate)': 209, 'Mozavaptan': 210, 'Bexarotene': 211, 'Sulfatinib': 212, 'Olanzapine': 213, 'AZD-7648': 214, 'Megestrol': 215, 'Omeprazole (sodium)': 216, 'Omeprazole': 217, 'Fedratinib (hydrochloride hydrate)': 218, 'Meloxicam': 219, 'Pyridoxine': 220, 'Pyridoxine (hydrochloride)': 221, 'Ornidazole': 222, 'Raltitrexed': 223, 'BI-3406': 224, 'Triamcinolone': 225, 'Drospirenone': 226, 'Eplerenone': 227, 'Quinestrol': 228, 'Estrone sulfate (potassium)': 229, 'Finasteride': 230, 'Fulvestrant': 231, 'Monocrotaline': 232, 'Ouabain (Octahydrate)': 233, 'Rutin (trihydrate)': 234, 'Hesperidin': 235, 'Digitoxin': 236, 'Doxorubicin (hydrochloride)': 237, 'Epirubicin (hydrochloride)': 238, 'Idarubicin (hydrochloride)': 239, 'Plicamycin': 240, 'Rifaximin': 241, 'Doxycycline (monohydrate)': 242, 'Fusidic acid': 243, 'Ipatasertib': 244, 'Medroxyprogesterone acetate': 245, 'Methylprednisolone succinate': 246, 'Dexamethasone': 247, 'Dihydroartemisinin': 248, 'Artesunate': 249, 'Artemether': 250, 'Rapamycin': 251, 'Temsirolimus': 252, 'Everolimus': 253, 'Tofacitinib': 254, 'Tofacitinib (citrate)': 255, 'Sonidegib': 256, 'AZD-8055': 257, 'Elimusertib hydrochloride': 258, 'Clobetasol propionate': 259, 'Betamethasone dipropionate': 260, 'Posaconazole': 261, 'Pravastatin (sodium)': 262, 'Ivermectin': 263, 'Topotecan (hydrochloride)': 264, 'Vinblastine (sulfate)': 265, 'vincristine': 266, 'Indacaterol (maleate)': 267, 'Pimitespib': 268, 'Irinotecan': 269, 'Irinotecan (hydrochloride)': 270, 'Dinaciclib': 271, 'Pioglitazone': 272, 'Volasertib': 273, 'Cyclosporin A': 274, 'Erythromycin': 275, 'Azithromycin (hydrate)': 276, 'Perindopril (erbumine)': 277, 'Sildenafil': 278, 'Budesonide': 279, 'Hexylresorcinol': 280, 'Oleic acid': 281, 'Fingolimod (hydrochloride)': 282, 'Daptomycin': 283, 'Orlistat': 284, 'Levobupivacaine (hydrochloride)': 285, 'Proglumide': 286, 'Ropivacaine (hydrochloride monohydrate)': 287, 'Macitentan': 288, 'Vemurafenib': 289, 'Lidocaine (hydrochloride)': 290, 'Sunitinib': 291, 'Procainamide (hydrochloride)': 292, 'Lucanthone': 293, 'RMC-6236': 294, 'Pemigatinib': 295, 'Infigratinib': 296, 'NG25': 297, 'Abemaciclib': 298, 'Bimatoprost': 299, 'Dorzolamide (hydrochloride)': 300, 'Tazarotene': 301, 'Neratinib': 302, 'Neratinib (maleate)': 303, 'Dapagliflozin': 304, 'Dapagliflozin ((2S)-1,2-propanediol, hydrate)': 305, 'Auranofin': 306, 'TAK-901': 307, 'Loperamide (hydrochloride)': 308, 'Ribociclib': 309, 'Altretamine': 310, 'Demeclocycline': 311, 'Afatinib': 312, 'Relugolix': 313, 'Citalopram (hydrobromide)': 314, 'Almonertinib (hydrochloride)': 315, 'Almonertinib (mesylate)': 316, 'Diphenhydramine': 317, 'ML264': 318, 'Methotrexate': 319, 'Ivabradine (hydrochloride)': 320, 'Rosiglitazone': 321, 'Piroxicam': 322, 'c-Kit-IN-1': 323, 'CP21R7': 324, '9-ING-41': 325, 'Binimetinib': 326, 'TAK-733': 327, 'Bendamustine': 328, 'Benztropine (mesylate)': 329, 'Tadalafil': 330, 'Vandetanib': 331, 'Glasdegib': 332, 'Isocorydine': 333, 'Berbamine': 334, 'Berbamine (dihydrochloride)': 335, 'Cepharanthine': 336, 'Sinomenine': 337, 'Adagrasib': 338, 'LB-100': 339, 'Entrectinib': 340, 'AZD2858': 341, 'Capmatinib': 342, 'Apalutamide': 343, 'Regorafenib': 344, 'Phenylephrine (hydrochloride)': 345, 'Rucaparib (phosphate)': 346, 'Clopidogrel': 347, 'Dimethyl fumarate': 348, 'Methyl aminolevulinate (hydrochloride)': 349, 'Mebendazole': 350, 'Tranilast': 351, 'Gefitinib': 352, 'Simotinib': 353, 'Bergenin': 354, 'Ferulic acid': 355, 'Amsacrine': 356, 'Palmatine (chloride)': 357, 'Berberine (chloride hydrate)': 358, 'Futibatinib': 359, 'Tubulin inhibitor 6': 360, 'Anethole trithione': 361, 'Cabozantinib (S-malate)': 362, 'Fluvoxamine': 363, 'Fluvoxamine (maleate)': 364, 'Erlotinib': 365, 'Belzutifan': 366, 'Vismodegib': 367, 'Nimesulide': 368, 'Nafamostat (mesylate)': 369, 'Busulfan': 370, '18β-Glycyrrhetinic acid': 371, 'Trametinib (DMSO_TF solvate)': 372, 'Pitavastatin (Calcium)': 373, 'Quinidine (15% dihydroquinidine)': 374, 'Canagliflozin (hemihydrate)': 375, 'Osimertinib (mesylate)': 376, 'γ-Oryzanol': 377}\n",
+      "377 ['[OH-].[OH-].[O-][Si]12O[Si]3(O[Si](O1)(O[Si](O2)(O3)[O-])[O-])[O-].[Mg+2].[Mg+2].[Mg+2]', 'B(C(CC(C)C)NC(=O)C(CC1=CC=CC=C1)NC(=O)C2=NC=CN=C2)(O)O', 'B(C(CC(C)C)NC(=O)CNC(=O)C1=C(C=CC(=C1)Cl)Cl)(O)O', 'B1(OC(=O)C(O1)(CC(=O)O)CC(=O)O)C(CC(C)C)NC(=O)CNC(=O)C2=C(C=CC(=C2)Cl)Cl', 'C.CC(C(=O)[O-])O.[Ca+2]', 'C.CC(C)NCC(COC1=CC=C(C=C1)COCCOC(C)C)O.C(=CC(=O)O)C(=O)O', 'C(=CC(=O)O)C(=O)O', 'C(=O)(N)NO', 'C(CC(C(F)F)(C(=O)O)N)CN.Cl', 'C(CS)N.Cl', 'C[As](C)SCC(C(=O)NCC(=O)O)NC(=O)CCC(C(=O)O)N', 'C=C1C(CC(C1CO)O)N2C=NC3=C2N=C(NC3=O)N.O', 'C1(C(=O)NC(=O)N1)NC(=O)N', 'C1=C(C(=O)NC(=O)N1)F', 'C1=C(C=C(C(=C1I)OC2=CC(=C(C(=C2)I)O)I)I)CC(C(=O)[O-])N.O.O.O.O.O.[Na+]', 'C1=C(C=C(C(=C1O)O)O)C(=O)O', 'C1=C(C=C(C(=C1O)O)O)C(=O)O.O', 'C1=CC(=C(C(=C1)Br)C(=O)C2=CNC(=C2)C(=O)NC3=CN=CC=C3)F', 'C1=CC(=C(C(=C1)Cl)COCCOCCCCCCNCC(C2=CC(=C(C=C2)O)CO)O)Cl', 'C1=CC(=C(C=C1[N+](=O)[O-])Cl)NC(=O)C2=C(C=CC(=C2)Cl)O.C(CO)N', 'C1=CC(=C(C=C1C(CN)O)O)O.Cl', 'C1=CC(=C(C=C1Cl)O)OC2=C(C=C(C=C2)Cl)Cl', 'C1=CC(=C2C(=C1NCCNCCO)C(=O)C3=C(C=CC(=C3C2=O)O)O)NCCNCCO.Cl.Cl', 'C1=CC(=CC=C1C(=N)N)OCCCCCOC2=CC=C(C=C2)C(=N)N.C(CS(=O)(=O)O)O.C(CS(=O)(=O)O)O', 'C1=CC(=CC=C1C(=O)NC(CCC(=O)O)C(=O)O)NCC2=CN=C3C(=N2)C(=O)NC(=N3)N', 'C1=CC(=CC=C1C(=O)NCCC(=O)[O-])N=NC2=CC(=C(C=C2)[O-])C(=O)O.O.O.[Na+].[Na+]', 'C1=CC(=CC=C1C=CC2=CC(=CC(=C2)O)O)O', 'C1=CC(=CC=C1C2=C(N=CC(=C2)C3=CN=C(C=C3)N)N)Cl', 'C1=CC(=CC=C1C2=COC3=C(C2=O)C=CC(=C3)OC4C(C(C(C(O4)CO)O)O)O)O', 'C1=CC(=CC=C1CCC2=CNC3=C2C(=O)NC(=N3)N)C(=O)NC(CCC(=O)O)C(=O)O', 'C1=CC(=CC=C1COC(CN2C=CN=C2)C3=C(C=C(C=C3)Cl)Cl)Cl', 'C1=CC(=CC=C1COC2=C(C=C(C=C2)CNCCO)OCC3=CC=C(C=C3)F)F.Cl', 'C1=CC(=CC=C1O)OC2C(C(C(C(O2)CO)O)O)O', 'C1=CC(=CN=C1)C=CC(=O)NCC2=CC=C(C=C2)C(=O)NC3=C(C=C(C=C3)F)N', 'C1=CC(=NC=C1CC2=CNC3=C2C=C(C=N3)Cl)NCC4=CN=C(C=C4)C(F)(F)F.Cl', 'C1=CC=C(C(=C1)C(=O)[O-])O.[Na+]', 'C1=CC=C(C(=C1)C(=O)O)O', 'C1=CC=C(C(=C1)C2=NC(=NO2)C3=CC(=CC=C3)C(=O)O)F', 'C1=CC=C(C(=C1)CC(=NNC2=NC(=CS2)C3=CC(=C(C=C3)Cl)Cl)C(=O)O)[N+](=O)[O-]', 'C1=CC=C(C=C1)C(C2=CC=CC=C2)(C3=CC=CC=C3Cl)N4C=CN=C4', 'C1=CC=C(C=C1)C2(C(=O)NC(=N2)[O-])C3=CC=CC=C3.[Na+]', 'C1=CC=C(C=C1)C2=C(C(=O)NC3=C2C=C(C=C3)Cl)C(=O)C=CC4=CC(=CN=C4)F', 'C1=CC=C(C=C1)C2=C(OC(=N2)CCC(=O)O)C3=CC=CC=C3', 'C1=CC=C(C=C1)C2=CC(=O)C3=C(C(=C(C=C3O2)OC4C(C(C(C(O4)C(=O)O)O)O)O)O)O', 'C1=CC=C(C=C1)NS(=O)(=O)C2=CC=CC(=C2)C=CC(=O)NO', 'C1=CC=C2C(=C1)C=CC3=CC=CC=C3N2C(=O)N', 'C1=CC=C2C(=C1)N=C3C(=C4C=C(C=CN4C3=N2)NC(=O)C5=CC=CS5)C#N', 'C1=CC2=C(C(=C1)O)N=CC=C2', 'C1=CC2=C(C=C1OC(F)(F)F)SC(=N2)N.Cl', 'C1=CC2=NC=C(N2C=C1)CC(O)(P(=O)(O)O)P(=O)(O)O', 'C1=CC2=NC=CC(=C2C=C1C=C3C(=O)NC(=O)S3)C4=CC=NC=C4', 'C1=CN(C(=O)N=C1N)C2C(C(C(O2)CO)O)(F)F', 'C1=CN(C(=O)N=C1N)C2C(C(C(O2)CO)O)O', 'C1=CN(C(=O)N=C1N)C2C(C(C(O2)CO)O)O.Cl', 'C1=CN(C(=O)NC1=O)C2C(C(C(O2)CO)O)O', 'C1=CN=C(C=N1)NNC(=O)C=CN2C=NC(=N2)C3=CC(=CC(=C3)C(F)(F)F)C(F)(F)F', 'C1=COC(=C1)CNC2=CC(=C(C=C2C(=O)O)S(=O)(=O)N)Cl', 'C1=NC(=C2C(=N1)N(C=N2)C3C(C(C(O3)CO)O)O)N', 'C1=NC(=NC(=O)N1C2C(C(C(O2)CO)O)O)N', 'C1=NC2=C(N=C(N=C2N1C3C(C(C(O3)CO)O)F)Cl)N', 'C1=NC2=NC=NC(=C2N1)N', 'C1=NNC2=C1C(=O)NC=N2', 'C1C(C(OC1N2C=C(C(=O)NC2=O)C(F)(F)F)CO)O', 'C1C(C(OC1N2C=C(C(=O)NC2=O)C=CBr)CO)O', 'C1C(C(OC1N2C=C(C(=O)NC2=O)I)CO)O', 'C1C(C(OC1N2C=NC(=NC2=O)N)CO)O', 'C1CC(=O)NC(=O)C1N2CC3=C(C2=O)C=CC=C3N.C1CC(=O)NC(=O)C1N2CC3=C(C2=O)C=CC=C3N.O', 'C1CC(C(C(C1)N2C3=CC=CC=C3OC4=CC=CC=C42)O)NS(=O)(=O)C5=CC=C(C=C5)OC(F)(F)F', 'C1CC(C1)(C2=CC=C(C=C2)C3=C(N4C(=N3)C=CC(=N4)C(=O)N)C5=CC=CC=C5)N', 'C1CC(N(C1)C2=NC3=C(C=NN3C=C2)NC(=O)N4CCC(C4)O)C5=C(C=CC(=C5)F)F', 'C1CC(N(C1)C2=NC3=C(C=NN3C=C2)NC(=O)N4CCC(C4)O)C5=C(C=CC(=C5)F)F.OS(=O)(=O)O', 'C1CC1C(=O)N2CCN(CC2)C(=O)C3=C(C=CC(=C3)CC4=NNC(=O)C5=CC=CC=C54)F', 'C1CC1C(=O)NC2=NN3C(=N2)C=CC=C3C4=CC=C(C=C4)CN5CCS(=O)(=O)CC5', 'C1CC1C(C(F)(F)F)NC(=O)C2=CC(=CS2)C3=C4N=CC(=CN4N=C3)C5=CC=C(C=C5)F', 'C1CCC(C(C1)[NH-])[NH-].C(=O)(C(=O)O)O.[Pt+2]', 'C1CCC(CC1)N2C(=NN=N2)CCCCOC3=CC4=C(C=C3)NC(=O)CC4', 'C1CCN(CC1)C(=O)N2CCN3C=C(C4=CC(=CC(=C43)C2)F)C5=C(C(=O)NC5=O)C6=CN=C7N6C=CC=C7', 'C1CCNC(C1)C2(CN(C2)C(=O)C3=C(C(=C(C=C3)F)F)NC4=C(C=C(C=C4)I)F)O', 'C1CN(CC1O)C2=C(C=C(C=N2)C(=O)NC3=CC=C(C=C3)OC(F)(F)Cl)C4=CC=NN4', 'C1CN(CCC1(C(=O)NC(CCO)C2=CC=C(C=C2)Cl)N)C3=NC=NC4=C3C=CN4', 'C1CN(CCC1(C2=CC(=C(C=C2)Cl)C(F)(F)F)O)CCCC(C3=CC=C(C=C3)F)C4=CC=C(C=C4)F', 'C1CN(CCC1CC(=O)N2CCC(CC2)C3C4=C(CCC5=C3N=CC(=C5)Br)C=C(C=C4Br)Cl)C(=O)N', 'C1CN(CCC1N2C3=CC=CC=C3NC2=O)CCCC(C4=CC=C(C=C4)F)C5=CC=C(C=C5)F', 'C1CN=C(N1)NC2=C(C=CC=C2Cl)Cl.Cl', 'C1CN=C(N1)NC2=C(C3=NC=CN=C3C=C2)Br', 'C1CNCCC1NC(=O)C2=C(C=NN2)NC(=O)C3=C(C=CC=C3Cl)Cl', 'C1CNCCN(C1)S(=O)(=O)C2=CC=CC3=C2C=CNC3=O', 'C1COC2=C(O1)C=CC(=C2)N3C(=O)NN=C3SC4=NC=C(S4)[N+](=O)[O-]', 'C1COCCN1C(=O)C2=CC=C(C=C2)C3=CN4C(=NC=C4C5=CC=C(C=C5)C#N)C=C3', 'C1COCCN1C2=CC=C(C=C2)C3=C(C=NC=C3)C4=CC(=C(C(=C4)F)O)F', 'C1COCCN1C2=NC(=NC(=N2)C3=CN=C(C=C3C(F)(F)F)N)N4CCOCC4', 'C1COCCN1CC2=CC=C(C=C2)COC3=NC=CC(=N3)C(C#N)C4=NC5=CC=CC=C5S4', 'C1CSSC1CCCCC(=O)O', 'CC(=CCCC(=CCCC(=CC=CC(=CC(=O)O)C)C)C)C', 'CC(=O)C1=CC=C(C=C1)NN=C(C2=NC(CC3=CC=CC=C32)(C)C)C(=O)N', 'CC(=O)C1=CC=C(C=C1)S(=O)(=O)NC(=O)NC2CCCCC2', 'CC(=O)CCCCN1C(=O)C2=C(N=CN2C)N(C1=O)C', 'CC(=O)NC(CC1=CC=C(C=C1)O)C(=O)NC(CCCN=C(N)N)C(=O)NC(CC2=CC=CC=C2)C(=O)N', 'CC(=O)NC1=NN=C(S1)S(=O)(=O)N', 'CC(=O)O.C1C(CN2C1C(=O)NC(C(=O)NC(C(=O)NC(C(=O)NC(C(=O)NC(C2=O)CC3=CC=CC=C3)CC4=CC=C(C=C4)OCC5=CC=CC=C5)CCCCN)CC6=CNC7=CC=CC=C76)C8=CC=CC=C8)OC(=O)NCCN', 'CC(=O)O.CC(=O)O.C1=CC(=CC=C1NC(=NC(=NCCCCCCN=C(N)N=C(N)NC2=CC=C(C=C2)Cl)N)N)Cl', 'CC(=O)OC1=CC=CC=C1C(=O)O', 'CC(=O)OC1CCC2(C3CCC4(C(C3CC=C2C1)CC=C4C5=CN=CC=C5)C)C', 'CC(C)(C)C(=O)OC1=CC=C(C=C1)S(=O)(=O)NC2=CC=CC=C2C(=O)NCC(=O)[O-].O.O.O.O.[Na+]', 'CC(C)(C)C(C(=O)NC(CC1=CC=CC=C1)C(CN(CC2=CC=C(C=C2)C3=CC=CC=N3)NC(=O)C(C(C)(C)C)NC(=O)OC)O)NC(=O)OC.OS(=O)(=O)O', 'CC(C)(C)C1=CC=C(C=C1)C(CCCN2CCC(CC2)C(C3=CC=CC=C3)(C4=CC=CC=C4)O)O', 'CC(C)(C)C1=CC=C(C=C1)S(=O)(=O)NC2=C(C(=NC(=N2)C3=NC=CC=N3)OCCO)OC4=CC=CC=C4OC.O', 'CC(C)(C)C1=NC(=C(S1)C2=NC(=NC=C2)N)C3=C(C(=CC=C3)NS(=O)(=O)C4=C(C=CC=C4F)F)F', 'CC(C)(C)CN1C2=C(C=CC(=N2)C3=C(N=C(N3)C(C)(C)C)C4=CC=C(C=C4)F)N=C1N.CS(=O)(=O)O.CS(=O)(=O)O', 'CC(C)(C)NC(=O)C1CC2CCCCC2CN1CC(C(CC3=CC=CC=C3)NC(=O)C(CC(=O)N)NC(=O)C4=NC5=CC=CC=C5C=C4)O', 'CC(C)(C)OC(=O)NCCC(=O)NC(CC1=CNC2=CC=CC=C21)C(=O)NC(CCSC)C(=O)NC(CC(=O)O)C(=O)NC(CC3=CC=CC=C3)C(=O)N', 'CC(C)(C#N)C1=CC(=CC(=C1)CN2C=NC=N2)C(C)(C)C#N', 'CC(C)(CCC(CC(=O)OC)(C(=O)OC1C2C3=CC4=C(C=C3CCN5C2(CCC5)C=C1OC)OCO4)O)O', 'CC(C)(CCCC(CC(=O)OC)(C(=O)OC1C2C3=CC4=C(C=C3CCN5C2(CCC5)C=C1OC)OCO4)O)O', 'CC(C)C(=O)NC1=CC(=C(C=C1)[N+](=O)[O-])C(F)(F)F', 'CC(C)C(C(=O)NC(CC1=CC=C(C=C1)O)C(=O)O)NC(=O)C(CC(=O)O)NC(=O)C(CCCCN)NC(=O)C(CCCN=C(N)N)N', 'CC(C)C(CC1=CC(=C(C=C1)OC)OCCCOC)CC(C(CC(C(C)C)C(=O)NCC(C)(C)C(=O)N)O)N', 'CC(C)C(CCCN(C)CCC1=CC(=C(C=C1)OC)OC)(C#N)C2=CC(=C(C=C2)OC)OC', 'CC(C)C(CCCN(C)CCC1=CC(=C(C=C1)OC)OC)(C#N)C2=CC(=C(C=C2)OC)OC.Cl', 'CC(C)C1=NC(=CS1)CN(C)C(=O)NC(C(C)C)C(=O)NC(CC2=CC=CC=C2)CC(C(CC3=CC=CC=C3)NC(=O)OCC4=CN=CS4)O', 'CC(C)CC(C(=O)NC(CCCN=C(N)N)C(=O)N1CCCC1C(=O)NNC(=O)N)NC(=O)C(COC(C)(C)C)NC(=O)C(CC2=CC=C(C=C2)O)NC(=O)C(CO)NC(=O)C(CC3=CNC4=CC=CC=C43)NC(=O)C(CC5=CN=CN5)NC(=O)C6CCC(=O)N6.CC(=O)O', 'CC(C)CC(C(=O)O)NC(=O)C(C(CC1=CC=CC=C1)N)O', 'CC(C)CC(C(=O)O)NC(=O)C(C(CC1=CC=CC=C1)N)O.Cl', 'CC(C)CN1C=NC2=C1C3=CC=CC=C3N=C2N.C(=CC(=O)O)C(=O)O', 'CC(C)CN1C=NC2=C1C3=CC=CC=C3N=C2N.Cl', 'CC(C)N1C=C(C(=N1)C2=C(C(=CC(=C2)Cl)NS(=O)(=O)C)F)C3=NC(=NC=C3)NCC(C)NC(=O)OC', 'CC(C)N1C2=C(C=NC3=CC(=C(C=C32)C4=CN=C(C=C4)OCCCN5CCCCC5)F)N(C1=O)C', 'CC(C)N1C2=NC=NC(=C2C(=N1)C3=CC4=C(C=C3)OC(=N4)N)N', 'CC(C)N1C2=NC=NC(=C2C(=N1)C3=CC4=C(N3)C=CC(=C4)O)N', 'CC(C)NC(=O)COC1=CC=CC(=C1)C2=NC3=CC=CC=C3C(=N2)NC4=CC5=C(C=C4)NN=C5', 'CC(C)NC(=O)COC1=CC=CC(=C1)C2=NC3=CC=CC=C3C(=N2)NC4=CC5=C(C=C4)NN=C5.CS(=O)(=O)O', 'CC(C)NCC(COC1=CC=C(C=C1)CCC(=O)OC)O.Cl', 'CC(C)NCCN(C1=CC2=NC(=CN=C2C=C1)C3=CN(N=C3)C)C4=CC(=CC(=C4)OC)OC', 'CC(C)OC(=O)C(=C1SC=CS1)C(=O)OC(C)C', 'CC(C)OC(=O)C(C)(C)OC1=CC=C(C=C1)C(=O)C2=CC=C(C=C2)Cl', 'CC(C)OC1=NC=C(C=C1)C2=NNC3=C2C=C(C=C3)NC(=O)C4(CCN(C4)CC(=O)N5CCC(=CC5)C6=CC=C(C=C6)C7=NN(C=N7)C)SC', 'CC(C1=C(C=CC(=C1Cl)F)Cl)OC2=C(N=CC(=C2)C3=CN(N=C3)C4CCNCC4)N', 'CC(C1=C(C=CC(=C1Cl)F)Cl)OC2=C(N=CC(=C2)C3=CN(N=C3)C4CCNCC4)N', 'CC(C1=C(C=CC(=C1Cl)F)Cl)OC2=C(N=CC(=C2)C3=CN(N=C3)C4CCNCC4)N.Cl', 'CC(C1=CC(=CC(=C1)C(F)(F)F)C(F)(F)F)OC2C(N(CCO2)CC3=NNC(=O)N3)C4=CC=C(C=C4)F', 'CC(C1=CC=CC2=CC=CC=C21)NCCCC3=CC(=CC=C3)C(F)(F)F', 'CC(C1=CC2=C(C=C1)C=C(C=C2)OC)C(=O)O', 'CC(C1=CC2=CC=CC=C2S1)N(C(=O)N)O', 'CC(C1=NC=NC=C1F)C(CN2C=NC=N2)(C3=C(C=C(C=C3)F)F)O', 'CC(CC1=CC(=C(C=C1)O)O)(C(=O)O)NN', 'CC(CC1=CC2=C(C(=C1)C(=O)N)N(CC2)CCCO)NCCOC3=CC=CC=C3OCC(F)(F)F', 'CC(CN1C=CC(=N1)C2=CC(=C(C=C2)C#N)Cl)NC(=O)C3=NNC(=C3)C(C)O', 'CC(COC1=CC=CC=C1CC2=CC=CC=C2)N3CCCCC3.OP(=O)(O)O', 'CC(CS(=O)(=O)C1=CC=C(C=C1)F)(C(=O)NC2=CC(=C(C=C2)C#N)C(F)(F)F)O', 'CC(CS)C(=O)N1CCCC1C(=O)O', 'CC#CC(=O)N1CCC(C1)N2C3=NC=NC(=C3N(C2=O)C4=CC=C(C=C4)OC5=CC=CC=C5)N', 'CC#CC(=O)N1CCC(C1)N2C3=NC=NC(=C3N(C2=O)C4=CC=C(C=C4)OC5=CC=CC=C5)N.Cl', 'CC#CC1(CCC2C1(CC(C3=C4CCC(=O)C=C4CCC23)C5=CC=C(C=C5)N(C)C)C)O', 'CC1(C(=O)N(C2=C(O1)C=CC(=N2)NC3=NC(=NC=C3F)NC4=CC(=C(C(=C4)OC)OC)OC)COP(=O)([O-])[O-])C.O.O.O.O.O.O.[Na+].[Na+]', 'CC1(C2=C(C=C(S2)C3=NC(=NC=C3)NC4=CC=NN4C)C(=O)N1CCN5CCOCC5)C', 'CC1(C2CC3C(C(=O)C(=C(C3(C(=O)C2=C(C4=C1C=CC=C4O)O)O)O)C(=O)N)N(C)C)O.Cl', 'CC1(C2CCC3(C(C2(CCC1OC4C(C(C(C(O4)C(=O)O)O)O)OC5C(C(C(C(O5)C(=O)O)O)O)O)C)C(=O)C=C6C3(CCC7(C6CC(CC7)(C)C(=O)O)C)C)C)C', 'CC1(C2CCC3(C(C2(CCC1OC4C(C(C(C(O4)C(=O)O)O)O)OC5C(C(C(C(O5)C(=O)O)O)O)O)C)C(=O)C=C6C3(CCC7(C6CC(CC7)(C)C(=O)O)C)C)C)C.N.N', 'CC1(CCC(=C(C1)C2=CC=C(C=C2)Cl)CN3CCN(CC3)C4=CC(=C(C=C4)C(=O)NS(=O)(=O)C5=CC(=C(C=C5)NCC6CCOCC6)[N+](=O)[O-])OC7=CN=C8C(=C7)C=CN8)C', 'CC1(CN2C=C(N=C2O1)[N+](=O)[O-])COC3=CC=C(C=C3)N4CCC(CC4)OC5=CC=C(C=C5)OC(F)(F)F', 'CC1=C(C(=CC=C1)C(C)C2=CN=CN2)C', 'CC1=C(C(=CC=C1)C)NC(=O)CN2CCN(CC2)CC(COC3=CC=CC=C3OC)O', 'CC1=C(C(=CC=C1)C)OCC(=O)NC(CC2=CC=CC=C2)C(CC(CC3=CC=CC=C3)NC(=O)C(C(C)C)N4CCCNC4=O)O', 'CC1=C(C(=NO1)C2=CC=CC=C2)C3=CC=C(C=C3)S(=O)(=O)N', 'CC1=C(C(=NO1)C2=CC=CC=C2Cl)C(=O)NC3C4N(C3=O)C(C(S4)(C)C)C(=O)[O-].[Na+]', 'CC1=C(C(=O)N(C(=O)N1CC2=C(C=CC=C2F)C(F)(F)F)CC(C3=CC=CC=C3)NCCCC(=O)[O-])C4=C(C(=CC=C4)OC)F.[Na+]', 'CC1=C(C(=O)N(C2=NC(=NC=C12)NC3=NC=C(C=C3)N4CCNCC4)C5CCCC5)C(=O)C', 'CC1=C(C(CCC1)(C)C)C=CC(=CC=CC(=CC(=O)O)C)C', 'CC1=C(C=C(C=C1)C(=O)NC)N2C(=CC(=C(C2=O)Br)OCC3=C(C=C(C=C3)F)F)C', 'CC1=C(C=C(C=C1)C(=O)NC2=CC(=C(C=C2)CN3CCN(CC3)C)C(F)(F)F)C#CC4=CN=C5N4N=CC=C5', 'CC1=C(C=C(C=C1)C(=O)NC2=CC(=CC(=C2)C(F)(F)F)N3C=C(N=C3)C)NC4=NC=CC(=N4)C5=NC=CN=C5', 'CC1=C(C=C(C=C1)C(=O)NC2=CC=CC(=C2)C(F)(F)F)NC3=C4C=NN(C4=NC(=N3)C5=CN=CC=C5)C', 'CC1=C(C=C(C=C1)C2C(C(C(C(O2)CO)O)O)O)CC3=CC=C(S3)C4=CC=C(C=C4)F', 'CC1=C(C=C(C=C1)OC2=NC3=C(N2)C=C(C(=C3)C4=CC=C(C=C4)C5=CC=CC=C5)Cl)C(=O)O', 'CC1=C(C=C(C=C1)OC2=NC3=C(N2)C=C(C(=C3)C4=CC5=C(C=C4)N(C=C5)C)Cl)C(=O)O', 'CC1=C(C=C(C=N1)NC(=O)C2=CC(=C(C=C2)CN3CCN(CC3)C)C(F)(F)F)NC4=NC=CC(=N4)C5=CN=CC=C5.CS(=O)(=O)O', 'CC1=C(C=CC(=C1)NC2=NC=NC3=C2C=C(C=C3)NC4=NC(CO4)(C)C)OC5=CC6=NC=NN6C=C5', 'CC1=C(C=CC2=C1C(=NC(=N2)N)N)CNC3=CC(=C(C(=C3)OC)OC)OC', 'CC1=C(C2=C(N1)C=CC(=C2)F)C3=NC4=C5C=CC=NC5=C6C(=C4N3)C=CC=N6', 'CC1=C(C2=CC=CC=C2C(=C1)OC(=O)C)OC(=O)C', 'CC1=C(C2=CC=CC=C2N1)CCNCC3=CC=C(C=C3)C=CC(=O)NO', 'CC1=C(N(N=C1C(=O)NN2CCCCC2)C3=C(C=C(C=C3)Cl)Cl)C4=CC=C(C=C4)Cl', 'CC1=C(N(N=C1C(=O)NN2CCCCC2)C3=C(C=C(C=C3)Cl)Cl)C4=CC=C(C=C4)Cl.Cl', 'CC1=C(N=C(C(=N1)C)C)C', 'CC1=C(ON=C1C)NS(=O)(=O)C2=CC=C(C=C2)N', 'CC1=C(SC(=N1)NC(=O)N2CCCC2C(=O)N)C3=CC(=NC=C3)C(C)(C)C(F)(F)F', 'CC1=C2C(=C(N(C1=O)C)NC3=C(C=C(C=C3)I)F)C(=O)N(C(=O)N2C4=CC=CC(=C4)NC(=O)C)C5CC5', 'CC1=C2C(=NC=C1)N(C3=C(C=CC=N3)C(=O)N2)C4CC4', 'CC1=C2C(=O)NC3(N2C(=O)C(=C1)NC4=NC=NC(=C4)N)CCCCC3', 'CC1=C2C(C(=O)C3(C(CC4C(C3C(C(C2(C)C)(CC1OC(=O)C(C(C5=CC=CC=C5)NC(=O)C6=CC=CC=C6)O)O)OC(=O)C7=CC=CC=C7)(CO4)OC(=O)C)O)C)OC(=O)C', 'CC1=C2C(C(=O)C3(C(CC4C(C3C(C(C2(C)C)(CC1OC(=O)C(C(C5=CC=CC=C5)NC(=O)OC(C)(C)C)O)O)OC(=O)C6=CC=CC=C6)(CO4)OC(=O)C)O)C)O', 'CC1=C2C(C(=O)C3(C(CC4C(C3C(C(C2(C)C)(CC1OC(=O)C(C(C5=CC=CC=C5)NC(=O)OC(C)(C)C)O)O)OC(=O)C6=CC=CC=C6)(CO4)OC(=O)C)O)C)O.O.O.O', 'CC1=C2C=C(C=CC2=C(C(=N1)C(=O)NCC(=O)O)O)OC3=CC=CC=C3', 'CC1=CC(=C(C=C1)C(C)C)O', 'CC1=CC(=C(C=C1)C)OCCCC(C)(C)C(=O)O', 'CC1=CC(=C(C=C1)SC2=CC=CC=C2N3CCNCC3)C', 'CC1=CC(=C(C2=C1NC(=O)C3=C2C=CS3)C4=CC=C(C=C4)C(C)CN)O', 'CC1=CC(=NN1)NC2=NC(=NC(=C2)C)C3CCC(CC3)(C(=O)NC(C)C4=CN=C(C=C4)N5C=C(C=N5)F)OC', 'CC1=CC(=O)C2=CC=CC=C2C1=O', 'CC1=CC(=O)N(C(=C1)C2CCCCC2)O', 'CC1=CC(=O)NC(=S)N1', 'CC1=CC=C(C=C1)C(=O)C2=CC(=C(C(=C2)O)O)[N+](=O)[O-]', 'CC1=CC=C(C=C1)C(=O)C2=CC=C(N2C)CC(=O)O', 'CC1=CC=C(C=C1)C2=CC(=NN2C3=CC=C(C=C3)S(=O)(=O)N)C(F)(F)F', 'CC1=CC=C(C=C1)S(=O)(=O)O.C[S+](CCC(C(=O)O)N)CC1C(C(C(O1)N2C=NC3=C(N=CN=C32)N)O)O.OS(=O)(=O)O.OS(=O)(=O)[O-]', 'CC1=CC=C(C=C1)S(=O)(=O)O.CC1=CC=C(C=C1)S(=O)(=O)O.CS(=O)(=O)CCNCC1=CC=C(O1)C2=CC3=C(C=C2)N=CN=C3NC4=CC(=C(C=C4)OCC5=CC(=CC=C5)F)Cl.O', 'CC1=CC=C(C=C1)S(=O)(=O)O.CN1C=C(N=C1C2CCN(CC2)C3=NC=NC4=C3C=NN4)C5=CC(=C(C=C5)F)C(F)(F)F', 'CC1=CC=C(C=C1)S(=O)(=O)O.CN1CCC2=C(C1)SC(=N2)C(=O)NC3CC(CCC3NC(=O)C(=O)NC4=NC=C(C=C4)Cl)C(=O)N(C)C.O', 'CC1=CC=C(C=C1)S(=O)(=O)O.CN1CCN2C3CCN(CC3C4=C2C1=CC=C4)CCCC(=O)C5=CC=C(C=C5)F', 'CC1=CC=CC=C1C(=O)NC2=CC=C(C=C2)C(=O)N3CCCC(C4=CC=CC=C43)N(C)C', 'CC1=CC2=C(C=C1C(=C)C3=CC=C(C=C3)C(=O)O)C(CCC2(C)C)(C)C', 'CC1=CC2=C(N1)C=CC(=C2)OC3=NC(=NC=C3)NC4=CC=CC(=C4)CS(=O)(=O)NCCN(C)C', 'CC1=CC2=C(S1)NC3=CC=CC=C3N=C2N4CCN(CC4)C', 'CC1=CC2=NC=NN2C=C1NC3=NC=C4C(=N3)N(C(=O)N4C)C5CCOCC5', 'CC1=CC2C(CCC3(C2CCC3(C(=O)C)O)C)C4(C1=CC(=O)CC4)C', 'CC1=CN=C(C(=C1OC)C)CS(=O)C2=NC3=C([N-]2)C=C(C=C3)OC.[Na+]', 'CC1=CN=C(C(=C1OC)C)CS(=O)C2=NC3=C(N2)C=C(C=C3)OC', 'CC1=CN=C(N=C1NC2=CC(=CC=C2)S(=O)(=O)NC(C)(C)C)NC3=CC=C(C=C3)OCCN4CCCC4.O.Cl.Cl', 'CC1=CN=C(S1)NC(=O)C2=C(C3=CC=CC=C3S(=O)(=O)N2C)O', 'CC1=NC=C(C(=C1O)CO)CO', 'CC1=NC=C(C(=C1O)CO)CO.Cl', 'CC1=NC=C(N1CC(CCl)O)[N+](=O)[O-]', 'CC1=NC2=C(C=C(C=C2)CN(C)C3=CC=C(S3)C(=O)NC(CCC(=O)O)C(=O)O)C(=O)N1', 'CC1=NC2=CC(=C(C=C2C(=N1)NC(C)C3=CC(=CC(=C3)N)C(F)(F)F)OC4CCOC4)OC', 'CC12CC(C3(C(C1CC(C2(C(=O)CO)O)O)CCC4=CC(=O)C=CC43C)F)O', 'CC12CCC(=O)C=C1C3CC3C4C2CCC5(C4C6CC6C57CCC(=O)O7)C', 'CC12CCC(=O)C=C1CC(C3C24C(O4)CC5(C3CCC56CCC(=O)O6)C)C(=O)OC', 'CC12CCC3C(C1CCC2(C#C)O)CCC4=C3C=CC(=C4)OC5CCCC5', 'CC12CCC3C(C1CCC2=O)CCC4=C3C=CC(=C4)OS(=O)(=O)[O-].[K+]', 'CC12CCC3C(C1CCC2C(=O)NC(C)(C)C)CCC4C3(C=CC(=O)N4)C', 'CC12CCC3C(C1CCC2O)C(CC4=C3C=CC(=C4)O)CCCCCCCCCS(=O)CCCC(C(F)(F)F)(F)F', 'CC1C(=O)OC2CCN3C2C(=CC3)COC(=O)C(C1(C)O)(C)O', 'CC1C(C(C(C(O1)OC2CC(C3(C4C(CCC3(C2)O)C5(CCC(C5(CC4O)C)C6=CC(=O)OC6)O)CO)O)O)O)O.O.O.O.O.O.O.O.O', 'CC1C(C(C(C(O1)OCC2C(C(C(C(O2)OC3=C(OC4=CC(=CC(=C4C3=O)O)O)C5=CC(=C(C=C5)O)O)O)O)O)O)O)O.O.O.O', 'CC1C(C(C(C(O1)OCC2C(C(C(C(O2)OC3=CC(=C4C(=O)CC(OC4=C3)C5=CC(=C(C=C5)OC)O)O)O)O)O)O)O)O', 'CC1C(C(CC(O1)OC2C(OC(CC2O)OC3C(OC(CC3O)OC4CCC5(C(C4)CCC6C5CCC7(C6(CCC7C8=CC(=O)OC8)O)C)C)C)C)O)O', 'CC1C(C(CC(O1)OC2CC(CC3=C2C(=C4C(=C3O)C(=O)C5=C(C4=O)C(=CC=C5)OC)O)(C(=O)CO)O)N)O.Cl', 'CC1C(C(CC(O1)OC2CC(CC3=C2C(=C4C(=C3O)C(=O)C5=C(C4=O)C(=CC=C5)OC)O)(C(=O)CO)O)N)O.Cl', 'CC1C(C(CC(O1)OC2CC(CC3=C2C(=C4C(=C3O)C(=O)C5=CC=CC=C5C4=O)O)(C(=O)C)O)N)O.Cl', 'CC1C(C(CC(O1)OC2CC(OC(C2O)C)OC3=CC4=CC5=C(C(=O)C(C(C5)C(C(=O)C(C(C)O)O)OC)OC6CC(C(C(O6)C)O)OC7CC(C(C(O7)C)O)OC8CC(C(C(O8)C)O)(C)O)C(=C4C(=C3C)O)O)O)O', 'CC1C=CC=C(C(=O)NC2=C(C3=C(C4=C(C(=C3O)C)OC(C4=O)(OC=CC(C(C(C(C(C(C1O)C)O)C)OC(=O)C)C)OC)C)C5=C2N6C=CC(=CC6=N5)C)O)C', 'CC1C2C(C3C(C(=O)C(=C(C3(C(=O)C2=C(C4=C1C=CC=C4O)O)O)O)C(=O)N)N(C)C)O.O', 'CC1C2CCC3(C(C2(CCC1O)C)C(CC4C3(CC(C4=C(CCC=C(C)C)C(=O)O)OC(=O)C)C)O)C', 'CC1CC(C2=C1C(=NC=N2)N3CCN(CC3)C(=O)C(CNC(C)C)C4=CC=C(C=C4)Cl)O', 'CC1CC2C(CCC3(C2CCC3(C(=O)C)OC(=O)C)C)C4(C1=CC(=O)CC4)C', 'CC1CC2C3CCC(C3(CC(C2C4(C1=CC(=O)C=C4)C)O)C)(C(=O)COC(=O)CCC(=O)O)O', 'CC1CC2C3CCC4=CC(=O)C=CC4(C3(C(CC2(C1(C(=O)CO)O)C)O)F)C', 'CC1CCC2C(C(OC3C24C1CCC(O3)(OO4)C)O)C', 'CC1CCC2C(C(OC3C24C1CCC(O3)(OO4)C)OC(=O)CCC(=O)O)C', 'CC1CCC2C(C(OC3C24C1CCC(O3)(OO4)C)OC)C', 'CC1CCC2CC(C(=CC=CC=CC(CC(C(=O)C(C(C(=CC(C(=O)CC(OC(=O)C3CCCCN3C(=O)C(=O)C1(O2)O)C(C)CC4CCC(C(C4)OC)O)C)C)O)OC)C)C)C)OC', 'CC1CCC2CC(C(=CC=CC=CC(CC(C(=O)C(C(C(=CC(C(=O)CC(OC(=O)C3CCCCN3C(=O)C(=O)C1(O2)O)C(C)CC4CCC(C(C4)OC)OC(=O)C(C)(CO)CO)C)C)O)OC)C)C)C)OC', 'CC1CCC2CC(C(=CC=CC=CC(CC(C(=O)C(C(C(=CC(C(=O)CC(OC(=O)C3CCCCN3C(=O)C(=O)C1(O2)O)C(C)CC4CCC(C(C4)OC)OCCO)C)C)O)OC)C)C)C)OC', 'CC1CCN(CC1N(C)C2=NC=NC3=C2C=CN3)C(=O)CC#N', 'CC1CCN(CC1N(C)C2=NC=NC3=C2C=CN3)C(=O)CC#N.C(C(=O)O)C(CC(=O)O)(C(=O)O)O', 'CC1CN(CC(O1)C)C2=NC=C(C=C2)NC(=O)C3=CC=CC(=C3C)C4=CC=C(C=C4)OC(F)(F)F', 'CC1COCCN1C2=NC(=NC3=C2C=CC(=N3)C4=CC(=C(C=C4)OC)CO)N5CCOCC5C', 'CC1COCCN1C2=NC3=C(C=CN=C3C4=CC=NN4)C(=C2)C5=CC=NN5C', 'CCC(=O)OC1(C(CC2C1(CC(C3(C2CCC4=CC(=O)C=CC43C)F)O)C)C)C(=O)CCl', 'CCC(=O)OCC(=O)C1(C(CC2C1(CC(C3(C2CCC4=CC(=O)C=CC43C)F)O)C)C)OC(=O)CC', 'CCC(C(C)O)N1C(=O)N(C=N1)C2=CC=C(C=C2)N3CCN(CC3)C4=CC=C(C=C4)OCC5CC(OC5)(CN6C=NC=N6)C7=C(C=C(C=C7)F)F', 'CCC(C)C(=O)OC1CC(C=C2C1C(C(C=C2)C)CCC(CC(CC(=O)[O-])O)O)O.[Na+]', 'CCC(C)C1C(CCC2(O1)CC3CC(O2)CC=C(C(C(C=CC=C4COC5C4(C(C=C(C5O)C)C(=O)O3)O)C)OC6CC(C(C(O6)C)OC7CC(C(C(O7)C)O)OC)OC)C)C', 'CCC1(C2=C(COC1=O)C(=O)N3CC4=CC5=C(C=CC(=C5CN(C)C)O)N=C4C3=C2)O.Cl', 'CCC1(CC2CC(C3=C(CCN(C2)C1)C4=CC=CC=C4N3)(C5=C(C=C6C(=C5)C78CCN9C7C(C=CC9)(C(C(C8N6C)(C(=O)OC)O)OC(=O)C)CC)OC)C(=O)OC)O.OS(=O)(=O)O', 'CCC1(CC2CC(C3=C(CCN(C2)C1)C4=CC=CC=C4N3)(C5=C(C=C6C(=C5)C78CCN9C7C(C=CC9)(C(C(C8N6C=O)(C(=O)OC)O)OC(=O)C)CC)OC)C(=O)OC)O.OS(=O)(=O)O', 'CCC1=C(C=C2CC(CC2=C1)NCC(C3=C4C=CC(=O)NC4=C(C=C3)O)O)CC.C(=CC(=O)O)C(=O)O', 'CCC1=C(C=CC(=C1)C(=O)N)N2C3=NC=CC(=C3C(=N2)C(C)C)N4C=C(N=C4)C5=CN(N=C5)C', 'CCC1=C2CN3C(=CC4=C(C3=O)COC(=O)C4(CC)O)C2=NC5=C1C=C(C=C5)OC(=O)N6CCC(CC6)N7CCCCC7', 'CCC1=C2CN3C(=CC4=C(C3=O)COC(=O)C4(CC)O)C2=NC5=C1C=C(C=C5)OC(=O)N6CCC(CC6)N7CCCCC7.Cl', 'CCC1=C2N=C(C=C(N2N=C1)NCC3=C[N+](=CC=C3)[O-])N4CCCCC4CCO', 'CCC1=CN=C(C=C1)CCOC2=CC=C(C=C2)CC3C(=O)NC(=O)S3', 'CCC1C(=O)N(C2=CN=C(N=C2N1C(C)C)NC3=C(C=C(C=C3)C(=O)NC4CCC(CC4)N5CCN(CC5)CC6CC6)OC)C', 'CCC1C(=O)N(CC(=O)N(C(C(=O)NC(C(=O)N(C(C(=O)NC(C(=O)NC(C(=O)N(C(C(=O)N(C(C(=O)N(C(C(=O)N(C(C(=O)N1)C(C(C)CC=CC)O)C)C(C)C)C)CC(C)C)C)CC(C)C)C)C)C)CC(C)C)C)C(C)C)CC(C)C)C)C', 'CCC1C(C(C(C(=O)C(CC(C(C(C(C(C(=O)O1)C)OC2CC(C(C(O2)C)O)(C)OC)C)OC3C(C(CC(O3)C)N(C)C)O)(C)O)C)C)O)(C)O', 'CCC1C(C(C(N(CC(CC(C(C(C(C(C(=O)O1)C)OC2CC(C(C(O2)C)O)(C)OC)C)OC3C(C(CC(O3)C)N(C)C)O)(C)O)C)C)C)O)(C)O.O.O', 'CCCC(C(=O)OCC)NC(C)C(=O)N1C2CCCCC2CC1C(=O)O.CC(C)(C)N', 'CCCC1=NN(C2=C1N=C(NC2=O)C3=C(C=CC(=C3)S(=O)(=O)N4CCN(CC4)C)OCC)C', 'CCCC1OC2CC3C4CCC5=CC(=O)C=CC5(C4C(CC3(C2(O1)C(=O)CO)C)O)C', 'CCCCCCC1=C(C=C(C=C1)O)O', 'CCCCCCCCC=CCCCCCCCC(=O)O', 'CCCCCCCCC1=CC=C(C=C1)CCC(CO)(CO)N.Cl', 'CCCCCCCCCC(=O)NC(CC1=CNC2=CC=CC=C21)C(=O)NC(CC(=O)N)C(=O)NC(CC(=O)O)C(=O)NC3C(OC(=O)C(NC(=O)C(NC(=O)C(NC(=O)CNC(=O)C(NC(=O)C(NC(=O)C(NC(=O)C(NC(=O)CNC3=O)CCCN)CC(=O)O)C)CC(=O)O)CO)C(C)CC(=O)O)CC(=O)C4=CC=CC=C4N)C', 'CCCCCCCCCCCC(CC1C(C(=O)O1)CCCCCC)OC(=O)C(CC(C)C)NC=O', 'CCCCN1CCCCC1C(=O)NC2=C(C=CC=C2C)C.Cl', 'CCCN(CCC)C(=O)C(CCC(=O)O)NC(=O)C1=CC=CC=C1', 'CCCN1CCCCC1C(=O)NC2=C(C=CC=C2C)C.O.Cl', 'CCCNS(=O)(=O)NC1=C(C(=NC=N1)OCCOC2=NC=C(C=N2)Br)C3=CC=C(C=C3)Br', 'CCCS(=O)(=O)NC1=C(C(=C(C=C1)F)C(=O)C2=CNC3=C2C=C(C=N3)C4=CC=C(C=C4)Cl)F', 'CCN(CC)CC(=O)NC1=C(C=CC=C1C)C.Cl', 'CCN(CC)CCNC(=O)C1=C(NC(=C1C)C=C2C3=C(C=CC(=C3)F)NC2=O)C', 'CCN(CC)CCNC(=O)C1=CC=C(C=C1)N.Cl', 'CCN(CC)CCNC1=C2C(=C(C=C1)C)SC3=CC=CC=C3C2=O', 'CCN1C2=C3C=C(C=C2)C4=CSC(=N4)CC(C(=O)N5CCCC(N5)C(=O)OCC(CC3=C1C6=C(N=CC(=C6)N7CCN(CC7)C)C(C)OC)(C)C)NC(=O)C8CC8C', 'CCN1C2=C3C=C(NC3=NC=C2CN(C1=O)C4=C(C(=CC(=C4F)OC)OC)F)CN5CCOCC5', 'CCN1CCN(CC1)C2=CC=C(C=C2)NC3=CC(=NC=N3)N(C)C(=O)NC4=C(C(=CC(=C4Cl)OC)OC)Cl', 'CCN1CCN(CC1)CC2=C(C=C(C=C2)NC(=O)C3=CC(=C(C=C3)C)OC4=C5C=CNC5=NC=C4)C(F)(F)F', 'CCN1CCN(CC1)CC2=CN=C(C=C2)NC3=NC=C(C(=N3)C4=CC5=C(C(=C4)F)N=C(N5C(C)C)C)F', 'CCNC(=O)CCCC=CCC1C(CC(C1C=CC(CCC2=CC=CC=C2)O)O)O', 'CCNC1CC(S(=O)(=O)C2=C1C=C(S2)S(=O)(=O)N)C.Cl', 'CCOC(=O)C1=CN=C(C=C1)C#CC2=CC3=C(C=C2)SCCC3(C)C', 'CCOC1=C(C=C2C(=C1)N=CC(=C2NC3=CC(=C(C=C3)OCC4=CC=CC=N4)Cl)C#N)NC(=O)C=CCN(C)C', 'CCOC1=C(C=C2C(=C1)N=CC(=C2NC3=CC(=C(C=C3)OCC4=CC=CC=N4)Cl)C#N)NC(=O)C=CCN(C)C.C(=CC(=O)O)C(=O)O', 'CCOC1=CC=C(C=C1)CC2=C(C=CC(=C2)C3C(C(C(C(O3)CO)O)O)O)Cl', 'CCOC1=CC=C(C=C1)CC2=C(C=CC(=C2)C3C(C(C(C(O3)CO)O)O)O)Cl.CC(CO)O.O', 'CCP(CC)CC.CC(=O)OCC1C(C(C(C(O1)[S-])OC(=O)C)OC(=O)C)OC(=O)C.[Au+]', 'CCS(=O)(=O)C1=CC=CC(=C1)C2=CC(=C(C3=C2C4=C(N3)N=CC(=C4)C)C)C(=O)NC5CCN(CC5)C', 'CN(C)C(=O)C(CCN1CCC(CC1)(C2=CC=C(C=C2)Cl)O)(C3=CC=CC=C3)C4=CC=CC=C4.Cl', 'CN(C)C(=O)C1=CC2=CN=C(N=C2N1C3CCCC3)NC4=NC=C(C=C4)N5CCNCC5', 'CN(C)C1=NC(=NC(=N1)N(C)C)N(C)C', 'CN(C)C1C2CC3C(C4=C(C=CC(=C4C(=C3C(=O)C2(C(=C(C1=O)C(=O)N)O)O)O)O)Cl)O', 'CN(C)CC=CC(=O)NC1=C(C=C2C(=C1)C(=NC=N2)NC3=CC(=C(C=C3)F)Cl)OC4CCOC4', 'CN(C)CC1=C(SC2=C1C(=O)N(C(=O)N2CC3=C(C=CC=C3F)F)C4=NN=C(C=C4)OC)C5=CC=C(C=C5)NC(=O)NOC', 'CN(C)CCCC1(C2=C(CO1)C=C(C=C2)C#N)C3=CC=C(C=C3)F.Br', 'CN(C)CCN(C)C1=CC(=C(C=C1NC(=O)C=C)NC2=NC=CC(=N2)C3=CN(C4=CC=CC=C43)C5CC5)OC.Cl', 'CN(C)CCN(C)C1=CC(=C(C=C1NC(=O)C=C)NC2=NC=CC(=N2)C3=CN(C4=CC=CC=C43)C5CC5)OC.CS(=O)(=O)O', 'CN(C)CCOC(C1=CC=CC=C1)C2=CC=CC=C2', 'CN(C1CCS(=O)(=O)CC1)C(=O)CNC(=O)C=CC2=CC(=CC=C2)Cl', 'CN(CC1=CN=C2C(=N1)C(=NC(=N2)N)N)C3=CC=C(C=C3)C(=O)NC(CCC(=O)O)C(=O)O', 'CN(CCCN1CCC2=CC(=C(C=C2CC1=O)OC)OC)CC3CC4=CC(=C(C=C34)OC)OC.Cl', 'CN(CCOC1=CC=C(C=C1)CC2C(=O)NC(=O)S2)C3=CC=CC=N3', 'CN1C(=C(C2=CC=CC=C2S1(=O)=O)O)C(=O)NC3=CC=CC=N3', 'CN1C=C(C=N1)C2=NC=CC(=C2)OC3=C(C=C(C(=C3)F)NC(=O)C4(CC4)C(=O)NC5=CC=CC=C5)F', 'CN1C=C(C2=CC=CC=C21)C3=C(C(=O)NC3=O)C4=CC(=CC=C4)N', 'CN1C=C(C2=CC3=C(C=C21)OCO3)C4=C(C(=O)NC4=O)C5=COC6=C5C=C(C=C6)F', 'CN1C=NC2=C1C=C(C(=C2F)NC3=C(C=C(C=C3)Br)F)C(=O)NOCCO', 'CN1C2=C(C(=C(C1=O)F)NC3=C(C=C(C=C3)I)F)C(=O)N(C=N2)CC(CO)O', 'CN1C2=C(C=C(C=C2)N(CCCl)CCCl)N=C1CCCC(=O)O', 'CN1C2CCC1CC(C2)OC(C3=CC=CC=C3)C4=CC=CC=C4.CS(=O)(=O)O', 'CN1CC(=O)N2C(C1=O)CC3=C(C2C4=CC5=C(C=C4)OCO5)NC6=CC=CC=C36', 'CN1CCC(CC1)COC2=C(C=C3C(=C2)N=CN=C3NC4=C(C=C(C=C4)Br)F)OC', 'CN1CCC(CC1C2=NC3=CC=CC=C3N2)NC(=O)NC4=CC=C(C=C4)C#N', 'CN1CCC2=CC(=C(C3=C2C1CC4=C3C(=C(C=C4)OC)O)OC)OC', 'CN1CCC2=CC(=C3C=C2C1CC4=CC=C(C=C4)OC5=C(C=CC(=C5)CC6C7=C(O3)C(=C(C=C7CCN6C)OC)OC)O)OC', 'CN1CCC2=CC(=C3C=C2C1CC4=CC=C(C=C4)OC5=C(C=CC(=C5)CC6C7=C(O3)C(=C(C=C7CCN6C)OC)OC)O)OC.Cl.Cl', 'CN1CCC2=CC3=C(C4=C2C1CC5=CC=C(C=C5)OC6=C(C=CC(=C6)CC7C8=CC(=C(C=C8CCN7C)OC)O4)OC)OCO3', 'CN1CCC23CC(=O)C(=CC2C1CC4=C3C(=C(C=C4)OC)O)OC', 'CN1CCCC1COC2=NC3=C(CCN(C3)C4=CC=CC5=C4C(=CC=C5)Cl)C(=N2)N6CCN(C(C6)CC#N)C(=O)C(=C)F', 'CN1CCN(CC1)C(=O)C2C3CCC(C2C(=O)O)O3', 'CN1CCN(CC1)C2=CC(=C(C=C2)C(=O)NC3=NNC4=C3C=C(C=C4)CC5=CC(=CC(=C5)F)F)NC6CCOCC6', 'CN1CCN(CC1)S(=O)(=O)C2=CC=C(C=C2)C3=CN=C(C(=N3)C(=O)NC4=CN=CC=C4)N', 'CNC(=O)C1=C(C=C(C=C1)C2=NN3C(=CN=C3N=C2)CC4=CC5=C(C=C4)N=CC=C5)F', 'CNC(=O)C1=C(C=C(C=C1)N2C(=S)N(C(=O)C23CCC3)C4=CC(=C(N=C4)C#N)C(F)(F)F)F', 'CNC(=O)C1=NC=CC(=C1)OC2=CC(=C(C=C2)NC(=O)NC3=CC(=C(C=C3)Cl)C(F)(F)F)F', 'CNCC(C1=CC(=CC=C1)O)O.Cl', 'CNCC1=CC=C(C=C1)C2=C3CCNC(=O)C4=C3C(=CC(=C4)F)N2.OP(=O)(O)O', 'COC(=O)C(C1=CC=CC=C1Cl)N2CCC3=C(C2)C=CS3', 'COC(=O)C=CC(=O)OC', 'COC(=O)CCC(=O)CN.Cl', 'COC(=O)NC1=NC2=C(N1)C=C(C=C2)C(=O)C3=CC=CC=C3', 'COC1=C(C=C(C=C1)C=CC(=O)NC2=CC=CC=C2C(=O)O)OC', 'COC1=C(C=C2C(=C1)N=CN=C2NC3=CC(=C(C=C3)F)Cl)OCCCN4CCOCC4', 'COC1=C(C=C2C(=C1)N=CN=C2NC3=CC(=C(C=C3)F)Cl)OCCN4CC5(CC5)C6(C4)OCCO6', 'COC1=C(C=C2C(=C1O)C3C(C(C(C(O3)CO)O)O)OC2=O)O', 'COC1=C(C=CC(=C1)C=CC(=O)O)O', 'COC1=C(C=CC(=C1)NS(=O)(=O)C)NC2=C3C=CC=CC3=NC4=CC=CC=C42', 'COC1=C(C2=C[N+]3=C(C=C2C=C1)C4=CC(=C(C=C4CC3)OC)OC)OC.[Cl-]', 'COC1=C(C2=C[N+]3=C(C=C2C=C1)C4=CC5=C(C=C4CC3)OCO5)OC.O.[Cl-]', 'COC1=CC(=CC(=C1)C#CC2=NN(C3=NC=NC(=C23)N)C4CCN(C4)C(=O)C=C)OC', 'COC1=CC=C(C=C1)C(=O)N2C3=CC=CC=C3SC4=C2C=C(C=C4)Cl', 'COC1=CC=C(C=C1)C2=CC(=S)SS2', 'COC1=CC2=C(C=CN=C2C=C1OC)OC3=CC=C(C=C3)NC(=O)C4(CC4)C(=O)NC5=CC=C(C=C5)F.C(C(C(=O)O)O)C(=O)O', 'COCCCCC(=NOCCN)C1=CC=C(C=C1)C(F)(F)F', 'COCCCCC(=NOCCN)C1=CC=C(C=C1)C(F)(F)F.C(=CC(=O)O)C(=O)O', 'COCCOC1=C(C=C2C(=C1)C(=NC=N2)NC3=CC=CC(=C3)C#C)OCCOC', 'CS(=O)(=O)C1=C2C(C(C(C2=C(C=C1)OC3=CC(=CC(=C3)C#N)F)F)F)O', 'CS(=O)(=O)C1=CC(=C(C=C1)C(=O)NC2=CC(=C(C=C2)Cl)C3=CC=CC=N3)Cl', 'CS(=O)(=O)NC1=C(C=C(C=C1)[N+](=O)[O-])OC2=CC=CC=C2', 'CS(=O)(=O)O.CS(=O)(=O)O.C1=CC(=CC=C1C(=O)OC2=CC3=C(C=C2)C=C(C=C3)C(=N)N)N=C(N)N', 'CS(=O)(=O)OCCCCOS(=O)(=O)C', 'C[C@]12CC[C@](C[C@H]1C3=CC(=O)[C@@H]4[C@]5(CC[C@@H](C([C@@H]5CC[C@]4([C@@]3(CC2)C)C)(C)C)O)C)(C)C(=O)O', ' CC1=C2C(=C(N(C1=O)C)NC3=C(C=C(C=C3)I)F)C(=O)N(C(=O)N2C4=CC=CC(=C4)NC(=O)C)C5CC5  ', ' C1C(C1)C2=NC3=CC=CC=C3C(=C2/C=C/[C@@H](O)C[C@@H](O)CC(=O)[O-])C4=CC=C(C=C4)F.C1C(C1)C2=NC3=CC=CC=C3C(=C2/C=C/[C@@H](O)C[C@@H](O)CC(=O)[O-])C4=CC=C(C=C4)F.[Ca+2]', 'COC1=CC2=C(C=CN=C2C=C1)[C@@H]([C@H]3C[C@@H]4CCN3C[C@@H]4C=C)O  ', 'CC1=C(C=C(C=C1)[C@H]2[C@@H]([C@H]([C@@H]([C@H](O2)CO)O)O)O)CC3=CC=C(S3)C4=CC=C(C=C4)F.CC1=C(C=C(C=C1)[C@H]2[C@@H]([C@H]([C@@H]([C@H](O2)CO)O)O)O)CC3=CC=C(S3)C4=CC=C(C=C4)F.O', 'CN1C=C(C2=CC=CC=C21)C3=NC(=NC=C3)NC4=C(C=C(C(=C4)NC(=O)C=C)N(C)CCN(C)C)OC.CS(=O)(=O)O  ', 'C[C@H](CCC=C(C)C)[C@H]1CC[C@@]2([C@@]1(CC[C@]34[C@H]2CC[C@@H]5[C@]3(C4)CC[C@@H](C5(C)C)OC(=O)/C=C/C6=CC(=C(C=C6)O)OC)C)C']\n"
+     ]
+    }
+   ],
+   "source": [
+    "drug_to_id = {\"<pad>\": 0}\n",
+    "chosen_smiles = []\n",
+    "i = 1\n",
+    "\n",
+    "for drug, smile in zip(drugs, smiles):\n",
+    "    if smile!=None:\n",
+    "        drug_to_id[drug]=i\n",
+    "        i += 1\n",
+    "        chosen_smiles.append(smile)\n",
+    "\n",
+    "\n",
+    "print(len(drug_to_id), drug_to_id)\n",
+    "print(len(chosen_smiles), chosen_smiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "with open(\"drug_to_id.json\", \"w\") as f:\n",
+    "    json.dump(drug_to_id, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating morgan fingerprints for 377 SMILES strings.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Generating fingerprints:   0%|          | 0/377 [00:00<?, ?it/s][17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "Generating fingerprints:  37%|███▋      | 139/377 [00:17<00:29,  7.96it/s]ase use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[17:44:09] DEPRECATION WARNING: \n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mKeyboardInterrupt\u001b[39m                         Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[11]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m fps = fps_np = np.zeros((\u001b[38;5;28mlen\u001b[39m(chosen_smiles)+\u001b[32m1\u001b[39m, \u001b[32m2048\u001b[39m))\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m fps[\u001b[32m1\u001b[39m:, :] = \u001b[43mgenerate_fingerprints\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchosen_smiles\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mmorgan\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[32;43m2\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m      3\u001b[39m fps_np[\u001b[32m1\u001b[39m:, :] = generate_fingerprints_np(chosen_smiles)\n\u001b[32m      4\u001b[39m fps.shape, fps_np.shape, fps, fps_np\n",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 11\u001b[39m, in \u001b[36mgenerate_fingerprints\u001b[39m\u001b[34m(smiles_list, fingerprint_type, radius)\u001b[39m\n\u001b[32m      9\u001b[39m     \u001b[38;5;28;01mcontinue\u001b[39;00m\n\u001b[32m     10\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m fingerprint_type == \u001b[33m\"\u001b[39m\u001b[33mmorgan\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m---> \u001b[39m\u001b[32m11\u001b[39m     fp = \u001b[43mAllChem\u001b[49m\u001b[43m.\u001b[49m\u001b[43mGetMorganFingerprintAsBitVect\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmol\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mradius\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     12\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m     13\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mUnknown fingerprint type: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfingerprint_type\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+      "\u001b[31mKeyboardInterrupt\u001b[39m: "
+     ]
+    },
+    {
+     "ename": "",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
+      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
+      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
+      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+     ]
+    }
+   ],
+   "source": [
+    "fps = fps_np = np.zeros((len(chosen_smiles)+1, 2048))\n",
+    "fps[1:, :] = generate_fingerprints(chosen_smiles, \"morgan\", 2)\n",
+    "fps_np[1:, :] = generate_fingerprints_np(chosen_smiles)\n",
+    "fps.shape, fps_np.shape, fps, fps_np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(378, 2048)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.save(\"drug_fps\", fps_np)\n",
+    "fps_np.shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -367,7 +367,7 @@ def main(cfg: DictConfig) -> composer.Trainer:
 
     # Build vocab
     vocab = GeneVocab.from_file(vocab_config["local"])
-    special_tokens = ["<pad>", "<cls>", "<eoc>"]
+    special_tokens = ["<pad>", "<cls>", "<eoc>", "<drug>"]
 
     for s in special_tokens:
         if s not in vocab:


### PR DESCRIPTION
Addresses #40 
- First version of multi-modal mosaicFM which uses the chemical info as an extra token is implemented.  

Summary of logic:
    - A <drug> token is inserted after the <cls> token in the pcpt_genes sequence. The value of this token is drug_id (comes from mapping of drug name to its corresponding row in nn.embedding layer) when the drug is available in dataset. When drug is not available, we use the pad_value (0 as default, which corresponds to first row of nn.embedding layer)
    - The drug_id is passed to a chem_encoder to generate a chem_embedding (initialized using Morgan fingerprints or ibm-encoding).
    -The embedding of <drug> token (second token in pcpt_genes) is replaced with the chem_embedding before the pcpt_genes is passed to the transformer.

Here is the schema of the model:
<img width="884" alt="chemtoken" src="https://github.com/user-attachments/assets/1a8c02a9-88c8-432f-a923-b0456449b88e" />

  