### PR TITLE
Added support for predicting log-trasnformed expressions instead of binned-values!

### DIFF
--- a/mosaicfm/data/dataloader.py
+++ b/mosaicfm/data/dataloader.py
@@ -69,6 +69,7 @@ def build_dataloader(
         do_mlm=collator_cfg.get("do_mlm", True),
         do_binning=collator_cfg.get("do_binning", True),
         log_transform=collator_cfg.get("log_transform", False),
+        log_preds=collator_cfg.get("log_preds", False),
         target_sum=collator_cfg.get("target_sum", 10000),
         mlm_probability=mlm_probability,
         mask_value=collator_cfg.mask_value,


### PR DESCRIPTION
Addresses issue #101 
- You can set log_preds=True in the collator config to use log-transformed values for gen_expressions (which will be compared against the model predictions), and the model will predict log-transformed expression levels.
- If log_preds=False, the behavior remains unchanged, and the model will predict binned expression values.