### PR TITLE
refactor: unify data collator

### DIFF
--- a/mosaicfm/data/collator.py
+++ b/mosaicfm/data/collator.py
@@ -1,6 +1,6 @@
 # Copyright (C) Vevo Therapeutics 2024-2025. All rights reserved.
 import json
-from typing import Dict, List, Mapping, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -43,11 +43,6 @@ class DataCollator(DefaultDataCollator):
             of the sequence to keep unchanged from sampling. This is useful when
             special tokens have been added to the beginning of the sequence.
             Default to 1.
-        data_style (:obj:`str`): the style of the data. If "pcpt", the data is
-            masked and padded for perception training. If "gen", only the gene
-            tokens are provided, but not the expression values, for pure generative
-            training setting. If "both", the output will contain both fields above.
-            Choices: "pcpt", "gen", "both". Default to "pcpt".
         num_bins (:obj:`int`): the number of bins to use for binning the expression
         right_binning (:obj:`bool`): whether to use right sided-binning. Torch default is False
     """
@@ -71,7 +66,6 @@ class DataCollator(DefaultDataCollator):
         sampling: bool = True,
         reserve_keys: Optional[List[str]] = None,
         keep_first_n_tokens: int = 1,
-        data_style: str = "pcpt",
         num_bins: int = 51,
         right_binning: bool = False,
         return_tensors: str = "pt",
@@ -91,7 +85,6 @@ class DataCollator(DefaultDataCollator):
         self.sampling = sampling
         self.reserve_keys = reserve_keys if reserve_keys is not None else []
         self.keep_first_n_tokens = keep_first_n_tokens
-        self.data_style = data_style
         self.num_bins = num_bins
         self.right_binning = right_binning
         # filter non_special gene_ids
@@ -162,9 +155,6 @@ class DataCollator(DefaultDataCollator):
                 f"({self.max_length}).",
             )
 
-        if self.data_style not in ["pcpt", "gen", "both"]:
-            raise ValueError("`data_style` must be one of 'pcpt', 'gen', 'both'.")
-
     def __call__(
         self,
         examples: List[Dict[str, torch.Tensor]],
@@ -198,247 +188,26 @@ class DataCollator(DefaultDataCollator):
             if isinstance(example["expressions"], list):
                 example["expressions"] = torch.as_tensor(example["expressions"])
             example["expressions"] = torch.squeeze(example["expressions"])
+
         if len(self.reserve_keys) > 0:
             assert all(key in examples[0] for key in self.reserve_keys), (
                 f"reserve_keys must be a subset of the keys in the examples. "
-                f"Got {self.reserve_keys} but expected keys in {list(examples[0].keys())}."
+                f"Got {self.reserve_keys} but expected keys in {list(examples[0].keys())}.",
             )
 
-        if self.data_style == "pcpt":
-            data_dict = self._call_pcpt(examples)
-        elif self.data_style == "gen":
-            data_dict = self._call_gen(examples)
-        elif self.data_style == "both":
-            data_dict = self._call_both(examples)
-
-        # add reserved keys
         device = examples[0]["genes"].device
-        for key in self.reserve_keys:
-            data_ = [example[key] for example in examples]
-            if isinstance(data_[0], torch.Tensor):
-                # if the reserved key is a tensor, stack them
-                data_dict[key] = torch.stack(data_, dim=0).to(device)
-            else:
-                data_dict[key] = data_  # if not tensor, just keep the list
-
-        return data_dict
-
-    def _call_pcpt(
-        self,
-        examples: List[Dict[str, torch.Tensor]],
-    ) -> Dict[str, torch.Tensor]:
-        """Each example is like:
-
-            {'id': tensor(184117),
-            'genes': tensor([36572, 17868, ..., 17072]),
-            'expressions': tensor([ 0.,  2., ..., 18.])}
-
-        Args:
-            examples (:obj:`List[Dict[str, torch.Tensor]]`): a list of examples.
-                Each example is a dictionary of tensors.
-        Returns:
-            :obj:`Dict[str, torch.Tensor]`: a dictionary of tensors.
-        """
-        if not isinstance(examples[0], Mapping):
-            raise NotImplementedError
-
-        device = examples[0]["genes"].device
-
         max_ori_len = max(len(example["genes"]) for example in examples)
         _max_length = self.max_length if max_ori_len >= self.max_length else max_ori_len
 
-        # pad and truncate
         padded_genes = []
-        padded_expressions = []
-        for i in range(len(examples)):
-            genes = examples[i]["genes"]
-            expressions = examples[i]["expressions"]
-            if self.do_binning:
-                expressions[self.keep_first_n_tokens :] = binning(
-                    row=expressions[self.keep_first_n_tokens :],
-                    n_bins=self.num_bins,
-                    right=self.right_binning,
-                )
-            elif self.log_transform:
-                assert not (
-                    self.do_binning
-                ), "Only one of `do_binning` and `log_transform` can be True."
-                expressions[self.keep_first_n_tokens :] = log_transform(
-                    row=expressions[self.keep_first_n_tokens :],
-                    target_sum=self.target_sum,
-                )
-            genes, expressions = self._sample_or_truncate_plus_pad(
-                genes,
-                expressions,
-                max_length=_max_length,
-            )  # torch tensors of length _max_length
-            padded_genes.append(genes)
-            padded_expressions.append(expressions)
+        masked_exprs = []
+        expr_targets = []
+        gen_masks = []
 
-        padded_genes = torch.stack(padded_genes, dim=0).to(device)
-        padded_expressions = torch.stack(padded_expressions, dim=0).to(device)
-
-        data_dict = {
-            "gene": padded_genes,
-            "expr": padded_expressions,
-        }
-
-        # mask
-        if self.do_mlm:
-            masked_expressions = self._mask(
-                padded_expressions,
-                self.keep_first_n_tokens,
-            )
-        else:
-            masked_expressions = padded_expressions
-        data_dict["masked_expr"] = masked_expressions
-
-        return data_dict
-
-    def _call_gen(
-        self,
-        examples: List[Dict[str, torch.Tensor]],
-    ) -> Dict[str, torch.Tensor]:
-        """This method will simply return the gene ids, with needed padding.
-        There is no masking for pure generative training, and no input of expr
-        values.
-
-        Each example is like:
-            {'id': tensor(184117),
-            'genes': tensor([36572, 17868, ..., 17072])}
-
-        Returns:
-            Dict[str, torch.Tensor]: a dict of tensors.
-            Example:
-                {'pcpt_gene': tensor([[36572, 17868, ..., 17072],
-                                        [36572, 17868, ..., 17072],
-                                        ...,
-                                        [36572, 17868, ..., 17072]]),
-                'pcpt_expr': tensor([[ 0.,  2., ..., 18.],
-                                        [ 0.,  2., ..., 18.],
-                                        ...,
-                                        [ 0.,  2., ..., 18.]])}
-        """
-
-        if not isinstance(examples[0], Mapping):
-            return NotImplementedError
-
-        device = examples[0]["genes"].device
-
-        max_ori_len = max(len(example["genes"]) for example in examples)
-        _max_length = self.max_length if max_ori_len >= self.max_length else max_ori_len
-
-        # pad and truncate
-        padded_pcpt_genes = []
-        padded_pcpt_expressions = []
-        for i in range(len(examples)):
-            genes = examples[i]["genes"]
-            expressions = examples[i]["expressions"]
-            if self.do_binning:
-                expressions[self.keep_first_n_tokens :] = binning(
-                    row=expressions[self.keep_first_n_tokens :],
-                    n_bins=self.num_bins,
-                    right=self.right_binning,
-                )
-            elif self.log_transform:
-                assert not (
-                    self.do_binning
-                ), "Only one of `do_binning` and `log_transform` can be True."
-                expressions[self.keep_first_n_tokens :] = log_transform(
-                    row=expressions[self.keep_first_n_tokens :],
-                    target_sum=self.target_sum,
-                )
-            genes, expressions = self._sample_or_truncate_plus_pad(
-                genes,
-                expressions,
-                max_length=_max_length,
-            )
-            padded_pcpt_genes.append(genes)
-            padded_pcpt_expressions.append(expressions)
-
-        padded_pcpt_genes = torch.stack(padded_pcpt_genes, dim=0).to(device)
-        padded_pcpt_expressions = torch.stack(padded_pcpt_expressions, dim=0).to(device)
-
-        data_dict = {
-            "pcpt_gene": padded_pcpt_genes,
-            "pcpt_expr": padded_pcpt_expressions,
-        }
-        return data_dict
-
-    def _call_both(
-        self,
-        examples: List[Dict[str, torch.Tensor]],
-        gen_prob: Optional[float] = None,
-    ) -> Dict[str, torch.Tensor]:
-        """This method will split the input into the peception part and the
-        generation part. The perception part will be processed into gene ids and
-        expr values, and the generation part will be processed into gene ids
-        only.
-
-        By default, the mlm_probability will be used to select the genese assigned to
-        the generation part.
-
-        Each example is like:
-            {'id': tensor(184117),
-            'genes': tensor([36572, 17868, ..., 17072]),
-            'expressions': tensor([ 0.,  2., ..., 18.])},
-            'drug_id': Optinal = tensor(256), id 0 refers to <pad> token and indicates that drug is not available
-
-        Args:
-            gen_prob (float, optional): the probability of a gene being assigned to
-                the generation part. If not provided, the mlm_probability will be used.
-
-        Returns:
-            Dict[str, torch.Tensor]: a dict of tensors.
-            Example:
-                {'pcpt_gene': tensor([[36572, 17868, ..., 17072],
-                                        [36572, 17868, ..., 17072],
-                                        ...,
-                                        [36572, 17868, ..., 17072]]),
-                'pcpt_expr': tensor([[ 0.,  2., ..., 18.],
-                                        [ 0.,  2., ..., 18.],
-                                        ...,
-                                        [ 0.,  2., ..., 18.]]),
-                'gen_gene': tensor([[36573, 17869, ..., 17073],
-                                        [36573, 17869, ..., 17073],
-                                        ...,
-                                        [36573, 17869, ..., 17073]]),
-                'gen_expr_target': tensor([[ 1.,  3., ..., 19.],
-                                        [ 1.,  3., ..., 19.],
-                                        ...,
-                                        [ 1.,  3., ..., 19.]])}
-        """
-        if not isinstance(examples[0], Mapping):
-            raise NotImplementedError
-
-        if not self.do_mlm:
-            # if not doing mlm, then the perceptrual part is the whole input
-            return self._call_gen(examples)
-
-        if gen_prob is None:
-            gen_prob = self.get_mlm_probability()
-
-        max_ori_len = max(len(example["genes"]) for example in examples)
-        _max_length = self.max_length if max_ori_len >= self.max_length else max_ori_len
-
-        gen_length = int((_max_length - self.keep_first_n_tokens) * gen_prob)
-        pcpt_length = _max_length - gen_length  # perception part length
-
-        # pad and truncate
-        padded_pcpt_genes = []
-        padded_pcpt_expressions = []
-        padded_pcpt_original_exp = []
-        padded_gen_genes = []
-        padded_gen_expressions = []
-        padded_gen_original_exp = []
-        drug_ids = [] if self.use_chem_token else None
-
-        for i in range(len(examples)):
-            genes = examples[i]["genes"]
-            expressions = examples[i]["expressions"]
-
+        for example in examples:
+            genes = example["genes"]
+            expressions = example["expressions"]
             if self.use_chem_token:
-                # add drug token <drug>, and pad_value=-2 expression at location 1  (after <cls>) of genes and expressions
                 genes = torch.cat(
                     (
                         genes[:1],
@@ -461,9 +230,7 @@ class DataCollator(DefaultDataCollator):
                         expressions[1:],
                     ),
                 )
-
             original_expressions = expressions.detach().clone()
-
             if self.do_binning:
                 expressions[self.keep_first_n_tokens :] = binning(
                     row=expressions[self.keep_first_n_tokens :],
@@ -471,139 +238,65 @@ class DataCollator(DefaultDataCollator):
                     right=self.right_binning,
                 )
             elif self.log_transform:
-                assert not (
-                    self.do_binning
-                ), "Only one of `do_binning` and `log_transform` can be True."
                 expressions[self.keep_first_n_tokens :] = log_transform(
                     row=expressions[self.keep_first_n_tokens :],
                     target_sum=self.target_sum,
                 )
 
-            (
-                gen_genes,
-                gen_expressions,
-                gen_original_exp,
-                pcpt_genes,
-                pcpt_expressions,
-                pcpt_original_exp,
-            ) = self._random_split(
-                genes[self.keep_first_n_tokens :],
-                expressions[self.keep_first_n_tokens :],
-                original_expressions[self.keep_first_n_tokens :],
-                ratio=gen_prob,
-            )
-            pcpt_genes = torch.cat(
-                (genes[: self.keep_first_n_tokens], pcpt_genes),
-                dim=0,
-            )
-            pcpt_expressions = torch.cat(
-                (expressions[: self.keep_first_n_tokens], pcpt_expressions),
-                dim=0,
-            )
-
-            pcpt_original_exp = torch.cat(
-                (original_expressions[: self.keep_first_n_tokens], pcpt_original_exp),
-                dim=0,
-            )
-
-            pcpt_genes, pcpt_expressions, pcpt_original_exp = (
-                self._sample_or_truncate_plus_pad(
-                    pcpt_genes,
-                    pcpt_expressions,
-                    pcpt_original_exp,
-                    max_length=pcpt_length,
+            gen_mask = example.get("gen_mask")
+            if gen_mask is not None:
+                if isinstance(gen_mask, list):
+                    gen_mask = torch.as_tensor(gen_mask)
+                gen_mask = torch.squeeze(gen_mask).bool()
+                if self.use_chem_token:
+                    gen_mask = torch.cat(
+                        (
+                            gen_mask[:1],
+                            torch.zeros(1, dtype=gen_mask.dtype, device=gen_mask.device),
+                            gen_mask[1:],
+                        ),
+                    )
+                genes, expressions, original_expressions, gen_mask = self._sample_or_truncate_plus_pad(
+                    genes,
+                    expressions,
+                    original_expressions,
+                    gen_mask,
+                    max_length=_max_length,
                 )
-            )  # torch tensors of length pcpt_length
-            padded_pcpt_genes.append(pcpt_genes)
-            padded_pcpt_expressions.append(pcpt_expressions)
-            padded_pcpt_original_exp.append(pcpt_original_exp)
-
-            gen_genes, gen_expressions, gen_original_exp = (
-                self._sample_or_truncate_plus_pad(
-                    gen_genes,
-                    gen_expressions,
-                    gen_original_exp,
-                    max_length=gen_length,
+            else:
+                genes, expressions, original_expressions = self._sample_or_truncate_plus_pad(
+                    genes,
+                    expressions,
+                    original_expressions,
+                    max_length=_max_length,
                 )
-            )  # torch tensors of length gen_length
-            padded_gen_genes.append(gen_genes)
-            padded_gen_expressions.append(gen_expressions)
-            padded_gen_original_exp.append(gen_original_exp)
+                if self.do_mlm:
+                    gen_mask = self._create_random_mask(expressions)
+                else:
+                    gen_mask = torch.zeros_like(expressions, dtype=torch.bool)
 
-            if self.use_chem_token:
-                # add drug id, id=0 corresponds to <pad> which indicates that drug is not available
-                drug = examples[i]["drug_id"]
-                drug_ids.append(drug)
+            masked_expr = expressions.masked_fill(gen_mask, self.mask_value)
 
-        padded_pcpt_genes = torch.stack(padded_pcpt_genes, dim=0)
-        padded_pcpt_expressions = torch.stack(padded_pcpt_expressions, dim=0)
-        padded_pcpt_original_exp = torch.stack(padded_pcpt_original_exp, dim=0)
-        padded_gen_genes = torch.stack(padded_gen_genes, dim=0)
-        padded_gen_expressions = torch.stack(padded_gen_expressions, dim=0)
-        padded_gen_original_exp = torch.stack(padded_gen_original_exp, dim=0)
+            padded_genes.append(genes)
+            masked_exprs.append(masked_expr)
+            expr_targets.append(original_expressions)
+            gen_masks.append(gen_mask)
 
-        if self.use_chem_token:
-            drug_ids = torch.stack(drug_ids)
+        data_dict = {
+            "genes": torch.stack(padded_genes, dim=0).to(device),
+            "expr": torch.stack(masked_exprs, dim=0).to(device),
+            "expr_target": torch.stack(expr_targets, dim=0).to(device),
+            "gen_mask": torch.stack(gen_masks, dim=0).to(device),
+        }
 
-            data_dict = {
-                "pcpt_gene": padded_pcpt_genes,
-                "pcpt_expr": padded_pcpt_expressions,
-                "pcpt_expr_raw": padded_pcpt_original_exp,  # "raw" means "not binned"
-                "gen_gene": padded_gen_genes,
-                "gen_expr_target": padded_gen_expressions,
-                "gen_expr_raw": padded_gen_original_exp,  # "raw" means "not binned"
-                "drug_ids": drug_ids,
-            }
-        else:
-            data_dict = {
-                "pcpt_gene": padded_pcpt_genes,
-                "pcpt_expr": padded_pcpt_expressions,
-                "pcpt_expr_raw": padded_pcpt_original_exp,  # "raw" means "not binned"
-                "gen_gene": padded_gen_genes,
-                "gen_expr_target": padded_gen_expressions,
-                "gen_expr_raw": padded_gen_original_exp,  # "raw" means "not binned"
-            }
+        for key in self.reserve_keys:
+            data_ = [example[key] for example in examples]
+            if isinstance(data_[0], torch.Tensor):
+                data_dict[key] = torch.stack(data_, dim=0).to(device)
+            else:
+                data_dict[key] = data_
+
         return data_dict
-
-    def _random_split(
-        self,
-        *arrays: torch.Tensor,
-        ratio: float,
-    ) -> Tuple[torch.Tensor, ...]:
-        """Randomly split the arrays into two parts. The first part will have
-        the.
-
-        length of `ratio * length`, and the second part will have the length of
-        `(1 - ratio) * length`. When multiple arrays are provided, they are supposed
-        to have the same length.
-
-        This method reflects the behavior of `sklearn.model_selection.train_test_split`
-
-        Args:
-            *arrays (torch.Tensor): the arrays to be split.
-            ratio (float): the ratio of the first part.
-
-        Returns:
-            Tuple[torch.Tensor, ...]: the split arrays.
-        """
-        assert len(arrays) > 0
-        assert 0 < ratio < 1
-        if len(arrays) > 1:
-            assert all(
-                array.shape[0] == arrays[0].shape[0] for array in arrays
-            ), "The arrays must have the same length."
-
-        length = arrays[0].shape[0]
-        split_index = int(length * ratio)
-
-        indices = torch.randperm(length, device=arrays[0].device)
-        first_part_indices = indices[:split_index]
-        second_part_indices = indices[split_index:]
-
-        first_parts = tuple(array[first_part_indices] for array in arrays)
-        second_parts = tuple(array[second_part_indices] for array in arrays)
-
-        return first_parts + second_parts
 
     def get_mlm_probability(self) -> float:
         """Get the mlm probability for the current step."""
@@ -618,33 +311,16 @@ class DataCollator(DefaultDataCollator):
                 f"but got {type(self.mlm_probability)} instead.",
             )
 
-    def _mask(
-        self,
-        expressions: torch.Tensor,
-        keep_first_n_tokens: int = 0,
-    ) -> torch.Tensor:
-        """Mask the expression values with MLM."""
-        if keep_first_n_tokens > 0:
-            result_ = self._mask(
-                expressions[:, keep_first_n_tokens:],
-                keep_first_n_tokens=0,
-            )
-            return torch.cat([expressions[:, :keep_first_n_tokens], result_], dim=1)
-
+    def _create_random_mask(self, expressions: torch.Tensor) -> torch.Tensor:
+        """Generate a random mask for expressions based on mlm probability."""
         device = expressions.device
         shape = expressions.shape
-
-        probability_matrix = torch.full(shape, self.get_mlm_probability())
-        # set padded postion probability to 0
+        probability_matrix = torch.full(shape, self.get_mlm_probability(), device=device)
         probability_matrix[expressions.eq(self.pad_value)] = 0
         if self.keep_first_n_tokens > 0:
             probability_matrix[:, : self.keep_first_n_tokens] = 0
-
         mask = torch.bernoulli(probability_matrix).bool()
-        mask = mask.to(device)
-
-        masked_expressions = expressions.masked_fill(mask, self.mask_value)
-        return masked_expressions
+        return mask
 
     def _sample_or_truncate_plus_pad(
         self,

--- a/mosaicfm/tasks/emb_extractor.py
+++ b/mosaicfm/tasks/emb_extractor.py
@@ -82,7 +82,6 @@ def get_batch_embeddings(
         mask_value=collator_cfg.mask_value,
         max_length=max_length,
         sampling=collator_cfg.sampling,  # Turned on since max-length can be less than the number of genes
-        data_style="pcpt",  # Disable splitting of genes into pcpt and gen for inference
         num_bins=collator_cfg.get("num_bins", 51),
         right_binning=collator_cfg.get("right_binning", False),
         keep_first_n_tokens=collator_cfg.get("keep_first_n_tokens", 1),
@@ -129,7 +128,7 @@ def get_batch_embeddings(
         count = 0
         pbar = tqdm(total=len(dataset), desc="Embedding cells")
         for data_dict in data_loader:
-            input_gene_ids = data_dict["gene"].to(device)
+            input_gene_ids = data_dict["genes"].to(device)
             src_key_padding_mask = ~input_gene_ids.eq(collator_cfg["pad_token_id"])
 
             embeddings = model._encode(

--- a/scripts/depmap/generate-embs-model.py
+++ b/scripts/depmap/generate-embs-model.py
@@ -255,7 +255,6 @@ def run_scgpt(base_path, model_path, model_name):
         mask_value=collator_config.mask_value,
         max_length=max_length,
         sampling=False,
-        data_style="pcpt",
         num_bins=collator_config.get("num_bins", 51),
         right_binning=collator_config.get("right_binning", False),
     )
@@ -289,7 +288,7 @@ def run_scgpt(base_path, model_path, model_name):
         for data_dict in data_loader:
 
             # get batch embeddings
-            input_gene_ids = data_dict["gene"].to(device)
+            input_gene_ids = data_dict["genes"].to(device)
             src_key_padding_mask = ~input_gene_ids.eq(collator_config["pad_token_id"])
             batch_embeddings = model.model._encode(
                 src=input_gene_ids,

--- a/scripts/inference/save_embeddings.py
+++ b/scripts/inference/save_embeddings.py
@@ -45,7 +45,6 @@ def main(cfg: DictConfig) -> None:
         mask_value=coll_cfg.mask_value,
         max_length=cfg.data.max_length,
         sampling=coll_cfg.sampling,
-        data_style="pcpt",
         num_bins=coll_cfg.get("num_bins", 51),
         right_binning=coll_cfg.get("right_binning", False),
         reserve_keys=cfg.data.reserve_keys,
@@ -112,7 +111,7 @@ def main(cfg: DictConfig) -> None:
         device_type=device.type,
     ):
         for batch in loader:
-            bs = batch["gene"].shape[0]
+            bs = batch["genes"].shape[0]
 
             # Rotate to a new ParquetWriter if starting a shard
             if writer is None:
@@ -129,7 +128,7 @@ def main(cfg: DictConfig) -> None:
             barcodes = batch["BARCODE_SUB_LIB_ID"]
 
             # Compute CLS embeddings
-            ids = batch["gene"].to(device)
+            ids = batch["genes"].to(device)
             expr = batch["expr"].to(device)
             mask = ~ids.eq(coll_cfg.pad_token_id)
             embs = model.model._encode(ids, expr, src_key_padding_mask=mask)


### PR DESCRIPTION
## Summary
- streamline DataCollator to always output genes, expr, expr_target and gen_mask
- update scripts and utilities to use unified collator interface

## Testing
- `pre-commit run --files mosaicfm/data/collator.py mosaicfm/tasks/emb_extractor.py scripts/depmap/generate-embs-model.py scripts/inference/save_embeddings.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'composer')*


------
https://chatgpt.com/codex/tasks/task_b_68956b0229a48329ae841d64517c73a4